### PR TITLE
Some improvements to Haskell and Vale configs

### DIFF
--- a/base/.config/project/vale.nix
+++ b/base/.config/project/vale.nix
@@ -30,6 +30,8 @@
       ## TODO: Have a general `ignores` list that we can process into
       ##       gitignores, `find -not` lists, etc.
       "*.nix"
+      "*.yaml"
+      "*.yml"
       "*/flake.lock"
       "./.cache/*"
       "./.config/mustache.yaml"

--- a/templates/haskell/.config/project/default.nix
+++ b/templates/haskell/.config/project/default.nix
@@ -36,7 +36,22 @@
       ## Haskell formatter
       programs.ormolu.enable = true;
     };
-    vale.enable = true;
+    vale = {
+      enable = true;
+      excludes = [
+        "*.cabal"
+        "*.hs"
+        "*.lhs"
+        "./cabal.project"
+      ];
+      vocab.${config.project.name}.accept = [
+        "comonad"
+        "functor"
+        "GADT"
+        "Kleisli"
+        "Kmett"
+      ];
+    };
   };
 
   ## CI

--- a/templates/haskell/flake.nix
+++ b/templates/haskell/flake.nix
@@ -10,7 +10,8 @@
     ];
     ## Isolate the build.
     registries = false;
-    sandbox = true;
+    ## TODO: Some checks currently don't work when sandboxed.
+    sandbox = false;
   };
 
   ### This is a complicated flake. Here’s the rundown:
@@ -41,6 +42,8 @@
       "ghc961"
       # "ghcHEAD" # doctest doesn’t work on current HEAD
     ];
+
+    supportedSystems = inputs.flake-utils.lib.defaultSystems;
 
     cabalPackages = pkgs: hpkgs:
       inputs.concat.lib.cabalProject2nix
@@ -92,12 +95,12 @@
                 ];
               })
             ])
-          inputs.flake-utils.lib.defaultSystems);
+          supportedSystems);
     }
     ## NB: This uses `eachSystem defaultSystems` instead of `eachDefaultSystem`
     ##     because users often have to locally replace `defaultSystems` with
     ##     their specific system to avoid issues with IFD.
-    // inputs.flake-utils.lib.eachSystem inputs.flake-utils.lib.defaultSystems
+    // inputs.flake-utils.lib.eachSystem supportedSystems
     (system: let
       pkgs = import inputs.nixpkgs {
         inherit system;


### PR DESCRIPTION
- have Vale ignore YAML files
- excludes Haskell files from Vale and some Haskell-y vocab
- don't sandbox Haskell projects
- abstract supported systems for Haskell