### PR TITLE
Eldev was skipping some linters

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "shellcheck-nix-attributes": "shellcheck-nix-attributes"
       },
       "locked": {
-        "lastModified": 1701068959,
-        "narHash": "sha256-9EkOn4rYXiIosLG8rjl/8uN1+OJ7QvbXSf4c4vkw1nc=",
+        "lastModified": 1701233823,
+        "narHash": "sha256-ZcCzmqc5Hc3rzeuPiQduyYyaM+Zxh/Ra525PMn+6ldg=",
         "owner": "sellout",
         "repo": "bash-strict-mode",
-        "rev": "6290c8aa90350a1109ccd80e4b53061afb1aadf1",
+        "rev": "8a050e56850f33f27d86a5f5f4c3de0ba2663d99",
         "type": "github"
       },
       "original": {
@@ -159,11 +159,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701206091,
-        "narHash": "sha256-o2rs3MAi1GbMYlILWD4nyJsPDqUfYoSfVtPgolp1OcM=",
+        "lastModified": 1701330994,
+        "narHash": "sha256-cottO70nyi124wTNec4cnNG8gzGna3CjEYjKyVb6bP0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9afc2703f6ac3fa8640a3e4484a12862e0876773",
+        "rev": "d31e4e801641afaa5105fcd044d638a2b8ac546f",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1701191397,
-        "narHash": "sha256-YRCjFcuRYNhSneSVclkv6SOmRFT0eVFRdVdplLDh5Ek=",
+        "lastModified": 1701333341,
+        "narHash": "sha256-+2gqTk7emjUF2wn3ahRUu3eYXRcr0fuN4FXLQKGfWaU=",
         "owner": "sellout",
         "repo": "project-manager",
-        "rev": "fc03e6e6369e65d3224012617124b8d9e6c31d2f",
+        "rev": "00973574e5ae63b1e0cf97e4061be62fee43015d",
         "type": "github"
       },
       "original": {

--- a/nix/lib/elisp.nix
+++ b/nix/lib/elisp.nix
@@ -69,7 +69,8 @@ in {
             echo
             echo "(mapcar"
             echo " 'eldev-use-local-dependency"
-            echo " '(\"${emacsPath pkgs.emacsPackages.dash}\""
+            echo " '(\"${emacsPath pkgs.emacsPackages.compat}\""
+            echo "   \"${emacsPath pkgs.emacsPackages.dash}\""
             echo "   \"${emacsPath pkgs.emacsPackages.elisp-lint}\""
             echo "   \"${emacsPath pkgs.emacsPackages.package-lint}\""
             echo "   \"${emacsPath pkgs.emacsPackages.relint}\""


### PR DESCRIPTION
There was a missing dependency (presumably induced by Nixpkgs 23.11) that caused
`eldev lint` to skip some linters, letting checks pass that should fail.