### PR TITLE
Improve elisp lib and template

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "shellcheck-nix-attributes": "shellcheck-nix-attributes"
       },
       "locked": {
-        "lastModified": 1701233823,
-        "narHash": "sha256-ZcCzmqc5Hc3rzeuPiQduyYyaM+Zxh/Ra525PMn+6ldg=",
+        "lastModified": 1701412668,
+        "narHash": "sha256-M9fQLKRtHzx2BhNuuFXbgvVKTCwZuYsrHet5Ha6SHqc=",
         "owner": "sellout",
         "repo": "bash-strict-mode",
-        "rev": "8a050e56850f33f27d86a5f5f4c3de0ba2663d99",
+        "rev": "c7e67ae5e40b7da0d6c168e046615ca4b0ac4025",
         "type": "github"
       },
       "original": {
@@ -159,11 +159,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701330994,
-        "narHash": "sha256-cottO70nyi124wTNec4cnNG8gzGna3CjEYjKyVb6bP0=",
+        "lastModified": 1701417047,
+        "narHash": "sha256-c7/mCMxHgrx+shWmdUtX/vThGeymGtZH4okg/gdtRco=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d31e4e801641afaa5105fcd044d638a2b8ac546f",
+        "rev": "742049b53ce0e0d1b5aacc5836d3edf32b9cd3b3",
         "type": "github"
       },
       "original": {

--- a/nix/lib/elisp.nix
+++ b/nix/lib/elisp.nix
@@ -48,10 +48,7 @@ in {
       });
 
     lint = pkgs: src: epkgs:
-    ## TODO: Can’t currently use `bash-strict-mode.lib.checkedDrv`
-    ##       because the `emacs` wrapper script checks for existence of a
-    ##       variable with `-n` intead of `-v`.
-      bash-strict-mode.lib.shellchecked pkgs
+      bash-strict-mode.lib.checkedDrv pkgs
       (pkgs.stdenv.mkDerivation {
         inherit src;
 
@@ -75,8 +72,6 @@ in {
             echo "   \"${emacsPath pkgs.emacsPackages.package-lint}\""
             echo "   \"${emacsPath pkgs.emacsPackages.relint}\""
             echo "   \"${emacsPath pkgs.emacsPackages.xr}\"))"
-            ## FIXME: Emacs’ CheckDoc seems to ignore this in .dir-locals.el.
-            echo "(setq sentence-end-double-space nil)"
           } >> Eldev
         '';
 
@@ -86,9 +81,12 @@ in {
           ##      `eldev--create-internal-pseudoarchive-descriptor`.
           export HOME="$PWD/fake-home"
           mkdir -p "$HOME"
+
           ## Need `--external` here so that we don’t try to download any
           ## package archives (which would break the sandbox).
-          eldev --external lint
+          ## TODO: I'm not sure why this needs `EMACSNATIVELOADPATH`, but it
+          ##       does.
+          EMACSNATIVELOADPATH= eldev --external lint --required
           runHook postBuild
         '';
 

--- a/templates/dhall/.config/project/default.nix
+++ b/templates/dhall/.config/project/default.nix
@@ -3,7 +3,7 @@
     name = "{{project.name}}";
     summary = "{{project.summary}}";
 
-    packages = [
+    devPackages = [
       pkgs.dhall
       pkgs.dhall-docs
       pkgs.dhall-lsp-server

--- a/templates/emacs-lisp/.config/emacs/.dir-locals.el
+++ b/templates/emacs-lisp/.config/emacs/.dir-locals.el
@@ -1,0 +1,6 @@
+;; TODO: We have to be careful what variables we set here. Some can cause the
+;;       Eldev linters to not read the settings here. See emacs-eldev/eldev#83.
+((nil
+  (fill-column . 80)
+  (indent-tabs-mode . nil)
+  (sentence-end-double-space . nil)))

--- a/templates/emacs-lisp/.config/project/default.nix
+++ b/templates/emacs-lisp/.config/project/default.nix
@@ -26,6 +26,8 @@
 
   ## formatting
   editorconfig.enable = true;
+  ## See the file for why this needs to force a different version.
+  project.file.".dir-locals.el".source = lib.mkForce ../emacs/.dir-locals.el;
   programs = {
     treefmt = {
       enable = true;

--- a/templates/emacs-lisp/Eldev
+++ b/templates/emacs-lisp/Eldev
@@ -5,6 +5,13 @@
 (setq
   ;; run all linters by default
   eldev-lint-default t
-  ;; except ‘package-lint’, because it’s also run within ‘elisp-lint’ (see
-  ;; ‘eldev-linter-elisp’)
-  eldev-lint-default-excluded '(package-lint))
+  ;; and disable the ‘elisp-lint’ validators that are already covered by
+  ;; ‘eldev-lint’ (see ‘eldev-linter-elisp’).
+  elisp-lint-ignored-validators '("checkdoc" "package-lint"))
+
+;; Uncomment and modify the following if this package uses
+;; ‘read-symbol-shorthands’.
+;; ;; Allow `read-symbol-shorthands` to work (see purcell/package-lint#238).
+;; (eval-after-load 'package-lint
+;;   '(add-to-list 'package-lint--allowed-prefix-mappings
+;;      '("elisp-reader" . ("er"))))


### PR DESCRIPTION
- use `strict-bash` consistently
- avoid issue with .dir-locals.el breaking linters
- have Eldev fail on skipped linters (previously, if a linter couldn't run for
  some reason, it would be silently skipped, and this led to lots of issues
  slipping through)
- improve how redundant linters are handled
- add an example for using `read-symbol-shorthands` successfully