### PR TITLE
More reliable loading of Emacs dependencies

### DIFF
--- a/templates/emacs-lisp/flake.nix
+++ b/templates/emacs-lisp/flake.nix
@@ -44,7 +44,7 @@
         builtins.listToAttrs
         (builtins.map
           (inputs.flaky.lib.homeConfigurations.example
-            ename
+            pname
             inputs.self
             [
               ({pkgs, ...}: {


### PR DESCRIPTION
Instead of having to list all transitive dependencies explicitly in Eldev, this
now pulls them from the `emacsWithPackages` derivation. This means
- new transitive dependencies won't break the build,
- we don't need to specify buttercup as the testing library universally, and
- Emacs packages with dependencies are easier to support.

Also corrects the name of the example Home Manager configurations for Emacs
Lisp.