### PR TITLE
Make Emacs Lisp packages work in sandbox

### DIFF
--- a/nix/lib/elisp.nix
+++ b/nix/lib/elisp.nix
@@ -93,9 +93,11 @@ in {
           export HOME="$PWD/fake-home"
           mkdir -p "$HOME"
 
+          ## Need `--external` here so that we don’t try to download any
+          ## package archives (which would break the sandbox).
           ## TODO: I'm not sure why this needs `EMACSNATIVELOADPATH`, but it
           ##       does.
-          EMACSNATIVELOADPATH= eldev lint --required
+          EMACSNATIVELOADPATH= eldev --external lint --required
           runHook postBuild
         '';
 
@@ -140,7 +142,9 @@ in {
         ##      `eldev--create-internal-pseudoarchive-descriptor`.
         export HOME="$PWD/fake-home"
         mkdir -p "$HOME"
-        eldev test
+        ## Need `--external` here so that we don’t try to download any
+        ## package archives (which would break the sandbox).
+        eldev --external test
         runHook postCheck
       '';
 
@@ -148,7 +152,9 @@ in {
 
       installCheckPhase = ''
         runHook preInstallCheck
-        eldev --packaged test
+        ## Need `--external` here so that we don’t try to download any
+        ## package archives (which would break the sandbox).
+        eldev --external --packaged test
         runHook postInstallCheck
       '';
     });


### PR DESCRIPTION
Eldev likes to do a lot of things that don't get along with Nix. In this case,
because there are checks that can't run in the sandbox, it's easy to overlook
sandbox violations until garnix catches them.

Without `--external`, Eldev will try to download various packages when linting
and testing. This restores the `--external` that used to be there and still
needs to be.

Just one more instance of sellout/project-manager#53.