### PR TITLE
Use the latest GH actions in Dhall template

### DIFF
--- a/templates/dhall/.config/project/default.nix
+++ b/templates/dhall/.config/project/default.nix
@@ -74,6 +74,6 @@
   services.github.enable = true;
   services.github.settings.repository = {
     homepage = "https://sellout.github.io/${config.project.name}";
-    topics = ["dhall" "library"];
+    topics = ["library"];
   };
 }

--- a/templates/dhall/.config/project/github-pages.nix
+++ b/templates/dhall/.config/project/github-pages.nix
@@ -41,10 +41,10 @@ in {
             }
             {
               name = "Setup Pages";
-              uses = "actions/configure-pages@v3";
+              uses = "actions/configure-pages@v4";
             }
             {
-              uses = "cachix/install-nix-action@v23";
+              uses = "cachix/install-nix-action@v24";
               "with".extra_nix_config = ''
               extra-trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
               extra-substituters = https://cache.garnix.io
@@ -80,7 +80,7 @@ in {
             {
               name = "Deploy to GitHub Pages";
               id = "deployment";
-              uses = "actions/deploy-pages@v2";
+              uses = "actions/deploy-pages@v3";
             }
           ];
         };


### PR DESCRIPTION
Also removes “dhall” from the GH labels, since that’s covered by the project language.