### PR TITLE
Fix Dhall highlighting in Emacs

### DIFF
--- a/templates/dhall/.config/emacs/.dir-locals.el
+++ b/templates/dhall/.config/emacs/.dir-locals.el
@@ -4,5 +4,6 @@
   (projectile-project-configure-cmd . "nix flake update")
   (sentence-end-double-space . nil))
  ("dhall"
-  ;; These files generally don’t have an extension
-  (mode . dhall)))
+  (nil
+   ;; These files generally don’t have an extension
+   (mode . dhall))))


### PR DESCRIPTION
.dir-locals.el doesn’t contain individual settings within subdirectory sections, it contains mode sections which then contain settings.