### PR TITLE
Improve Haskell template

### DIFF
--- a/templates/haskell/.config/project/github-ci.nix
+++ b/templates/haskell/.config/project/github-ci.nix
@@ -9,13 +9,16 @@
       ];
     };
     jobs.build = {
-      runs-on = "ubuntu-latest";
       strategy = {
         fail-fast = false;
-        ## TODO: Populate this as the difference between supported versions and
-        ##       available nix package sets.
-        matrix.ghc = self.lib.nonNixTestedGhcVersions;
+        matrix = {
+          ## TODO: Populate this as the difference between supported versions
+          ##       and available nix package sets.
+          ghc = self.lib.nonNixTestedGhcVersions;
+          os = ["macos-13" "ubuntu-22.04" "windows-2022"];
+        };
       };
+      runs-on = "\${{ matrix.os }}";
       env.CONFIG = "--enable-tests --enable-benchmarks";
       steps = [
         {uses = "actions/checkout@v4";}

--- a/templates/haskell/README.md
+++ b/templates/haskell/README.md
@@ -2,7 +2,7 @@
 
 [![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io)
 [![Packaging status](https://repology.org/badge/tiny-repos/haskell:{{project.name}}.svg)](https://repology.org/project/haskell:{{project.name}}/versions)
-[![latest packaged version(s)](https://repology.org/badge/latest-versions/haskell:{{project.name}}.svg)](https://repology.org/project/haskell:{{project.name}}/versions)
+[![latest packaged versions](https://repology.org/badge/latest-versions/haskell:{{project.name}}.svg)](https://repology.org/project/haskell:{{project.name}}/versions)
 
 {{project.summary}}
 

--- a/templates/haskell/{{project.name}}/Setup.hs
+++ b/templates/haskell/{{project.name}}/Setup.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE PackageImports #-}
+
+module Main where
+
+import "cabal-doctest" Distribution.Extra.Doctest (defaultMainWithDoctests)
+
+main :: IO ()
+main = defaultMainWithDoctests "doctests"

--- a/templates/haskell/{{project.name}}/tests/doctests.hs
+++ b/templates/haskell/{{project.name}}/tests/doctests.hs
@@ -1,7 +1,10 @@
-module Main where
+module Main (main) where
 
-import Build_doctests (flags, module_sources, pkgs)
-import Test.DocTest (doctest)
+import "base" Data.Function (($))
+import "base" Data.Semigroup (Semigroup ((<>)))
+import "base" System.IO (IO)
+import "doctest" Test.DocTest (doctest)
+import "this" Build_doctests (flags, module_sources, pkgs)
 
 main :: IO ()
-main = doctest (flags <> pkgs <> module_sources)
+main = doctest $ flags <> pkgs <> module_sources

--- a/templates/haskell/{{project.name}}/{{project.name}}.cabal
+++ b/templates/haskell/{{project.name}}/{{project.name}}.cabal
@@ -1,43 +1,129 @@
-cabal-version:  2.4
+cabal-version:  3.0
 
-name:           {{project.name}}
-version:        {{project.version}}
-synopsis:       {{project.summary}}
-description:    {{project.description}}
-homepage:       https://github.com/{{project.repo}}#readme
-bug-reports:    https://github.com/{{project.repo}}/issues
-build-type:     Custom
-license:        AGPL-3.0-or-later
-license-file:   LICENSE
-tested-with:    GHC==8.6.1,
-                GHC==8.8.1,
-                GHC==8.10.1, GHC==8.10.7,
-                GHC==9.0.1, GHC==9.0.2,
-                GHC==9.2.1, GHC==9.2.8,
-                GHC==9.4.1, GHC==9.4.5,
-                GHC==9.6.1
+name:        {{project.name}}
+version:     {{project.version}}
+synopsis:    {{project.summary}}
+description: {{project.description}}
+author:      Greg Pfeil <greg@technomadic.org>
+maintainer:  Greg Pfeil <greg@technomadic.org>
+copyright:   2024 Greg Pfeil
+homepage:    https://github.com/{{project.repo}}#readme
+bug-reports: https://github.com/{{project.repo}}/issues
+category:
+build-type:  Custom
+license:     AGPL-3.0-or-later
+license-files:
+  LICENSE
+tested-with:
+  GHC == {
+--  GHCup   Nixpkgs
+    7.10.3,
+    8.0.1,
+    8.2.1,
+    8.4.1,
+    8.6.1,
+    8.8.1,  8.8.4,
+    8.10.1, 8.10.7,
+    9.0.1,  9.0.2,
+    9.2.1,  9.2.8,
+    9.4.1,  9.4.8,
+    9.6.1,  9.6.2,
+            9.8.1
+  }
 
 source-repository head
   type: git
   location: https://github.com/{{project.repo}}
 
+-- This mimics the GHC2021 extension
+-- (https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html?highlight=doandifthenelse#extension-GHC2021),
+-- but supporting compilers back to GHC 7.10. If the oldest supported compiler
+-- is GHC 9.2, then this stanza can be removed and `import: GHC2021` can be
+-- replaced by `default-language: GHC2021`.
+common GHC2021
+  default-language: Haskell2010
+  default-extensions:
+    BangPatterns
+    BinaryLiterals
+    ConstraintKinds
+    DeriveDataTypeable
+    DeriveGeneric
+    -- DeriveLift -- uncomment if the oldest supported version is GHC 8.10.1+
+    DeriveTraversable
+    DerivingStrategies
+    DoAndIfThenElse
+    EmptyCase
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    GADTSyntax
+    GeneralizedNewtypeDeriving
+    -- HexFloatLiterals -- uncomment if the oldest supported version is GHC 8.4.1+
+    -- ImportQualifiedPost -- uncomment if the oldest supported version is GHC 8.10.1+
+    InstanceSigs
+    LambdaCase
+    MagicHash
+    MonadComprehensions
+    MonomorphismRestriction
+    MultiParamTypeClasses
+    NamedFieldPuns
+    NamedWildCards
+    -- NumericUnderscores -- uncomment if the oldest supported version is GHC 8.6.1+
+    PolyKinds
+    PostfixOperators
+    RankNTypes
+    ScopedTypeVariables
+    StandaloneDeriving
+    -- StandaloneKindSignatures -- uncomment if the oldest supported version is GHC 8.10.1+
+    TupleSections
+    -- TypeApplications -- uncomment if the oldest supported version is GHC 8.0.1+
+    TypeOperators
+    UnicodeSyntax
+    NoExplicitNamespaces
+
+common defaults
+  import: GHC2021
+  build-depends:
+    base ^>= {4.8.2, 4.9.0, 4.10.0, 4.11.0, 4.12.0, 4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0},
+  ghc-options:
+    -Wall
+  default-extensions:
+    DefaultSignatures
+    ExplicitNamespaces
+    FunctionalDependencies
+    LiberalTypeSynonyms
+    -- replace with `LexicalNegation` if the oldest supported version is GHC 9.0.1+
+    NegativeLiterals
+    PackageImports
+    ParallelListComp
+    -- QualifiedDo - uncomment if the oldest supported version is GHC 9.0.1+
+    RecursiveDo
+    -- RequiredTypeArguments - uncomment if the oldest supported version is GHC 9.10.1+
+    Safe
+    -- StrictData - uncomment if the oldest supported version is GHC 8.0.1+
+    -- TemplateHaskellQuotes - uncomment if the oldest supported version is GHC 8.0.1+
+    TransformListComp
+    NoGeneralizedNewtypeDeriving
+    NoImplicitPrelude
+    NoMonomorphismRestriction
+    NoPatternGuards
+    -- NoTypeApplications - uncomment if the oldest supported version is GHC 8.0.1+
+
 custom-setup
   setup-depends:
-    base          >= 4.14.3 && < 4.19,
-    cabal-doctest >= 1.0.0  && < 1.1
+    base ^>= {4.8.2, 4.9.0, 4.10.0, 4.11.0, 4.12.0, 4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0},
+    cabal-doctest ^>= 1.0.0,
 
 library
+  import: defaults
   build-depends:
-    base >= 4.14.3 && < 4.19
-  default-language: Haskell2010
   exposed-modules:
-  ghc-options: -Wall
 
-test-suite {{project.name}}-doctests
+test-suite doctests
+  import: defaults
   type: exitcode-stdio-1.0
   hs-source-dirs: tests
   main-is: doctests.hs
   build-depends:
-    base    >= 4.14.3 && < 4.19,
-    doctest >= 0.15.0 && < 0.22,
-    {{project.name}}
+    doctest ^>= {0.15.0, 0.16.0, 0.17.0, 0.18.0, 0.19.0, 0.20.0, 0.21.0},
+    {{project.name}},


### PR DESCRIPTION
This adds a comprehensive `default-extensions`, broader GHC support, updated dependency bounds (and syntax for them), and a few other things.