### PR TITLE
Another set of changes to the Haskell template

### DIFF
--- a/templates/haskell/.config/project/default.nix
+++ b/templates/haskell/.config/project/default.nix
@@ -1,4 +1,14 @@
-{config, flaky, lib, pkgs, self, supportedSystems, ...}: {
+{
+  config,
+  flaky,
+  lib,
+  pkgs,
+  self,
+  supportedSystems,
+  ...
+}: let
+  githubSystems = ["macos-13" "ubuntu-22.04" "windows-2022"];
+in {
   project = {
     name = "{{project.name}}";
     summary = "{{project.summary}}";
@@ -10,7 +20,8 @@
   };
 
   imports = [
-    ./github-ci.nix
+    (import ./github-ci.nix githubSystems)
+    ./hackage-publish.nix
     ./hlint.nix
   ];
 
@@ -64,22 +75,49 @@
   ## CI
   services.garnix = {
     enable = true;
-    builds.exclude = [
-      # TODO: Remove once garnix-io/garnix#285 is fixed.
-      "homeConfigurations.x86_64-darwin-${config.project.name}-example"
-    ];
+    builds = {
+      exclude = [
+        # TODO: Remove once garnix-io/garnix#285 is fixed.
+        "homeConfigurations.x86_64-darwin-${config.project.name}-example"
+      ];
+      include = lib.mkForce (
+        [
+          "homeConfigurations.*"
+          "nixosConfigurations.*"
+        ]
+        ++ lib.concatLists (
+          flaky.lib.garnixChecks
+          (
+            sys:
+              [
+                "checks.${sys}.*"
+                "devShells.${sys}.*"
+                "packages.${sys}.default"
+              ]
+              ++ map (ghc: "packages.${sys}.${ghc}_all")
+              (self.lib.testedGhcVersions sys)
+          )
+        )
+      );
+    };
   };
   ## FIXME: Shouldn’t need `mkForce` here (or to duplicate the base contexts).
   ##        Need to improve module merging.
   services.github.settings.branches.main.protection.required_status_checks.contexts =
     lib.mkForce
-      (map (ghc: "CI / build (${ghc}) (pull_request)") self.lib.nonNixTestedGhcVersions
+    (lib.concatMap (sys:
+        lib.concatMap (ghc: [
+          "build (${ghc}, ${sys})"
+          "build (--prefer-oldest, ${ghc}, ${sys})"
+        ])
+        self.lib.nonNixTestedGhcVersions)
+      githubSystems
       ++ flaky.lib.forGarnixSystems supportedSystems (sys:
         lib.concatMap (ghc: [
           "devShell ghc${ghc} [${sys}]"
           "package ghc${sys}_all [${sys}]"
         ])
-        (self.lib.testedGhcVersions pkgs.system)
+        (self.lib.testedGhcVersions sys)
         ++ [
           "homeConfig ${sys}-${config.project.name}-example"
           "package default [${sys}]"
@@ -91,6 +129,8 @@
         ]));
 
   ## publishing
-  services.flakehub.enable = true;
+  # NB: Can’t use IFD on FlakeHub (see DeterminateSystems/flakehub-push#69), so
+  #     this is disabled until we have a way to build Haskell without IFD.
+  services.flakehub.enable = false;
   services.github.enable = true;
 }

--- a/templates/haskell/.config/project/hackage-publish.nix
+++ b/templates/haskell/.config/project/hackage-publish.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  pkgs,
+  self,
+  ...
+}: {
+  services.github.workflow."hackage-publish.yml".text = lib.generators.toYAML {} {
+    name = "Publish release to Hackage";
+    on = {
+      push.tags = ["v?[0-9]+.[0-9]+.[0-9]+*"];
+      workflow_dispatch.inputs.tag = {
+        description = "The existing version to publish to Hackage";
+        type = "string";
+        required = true;
+      };
+    };
+    jobs.hackage-publish = {
+      runs-on = "ubuntu-latest";
+      permissions = {
+        id-token = "write";
+        contents = "read";
+      };
+      steps = [
+        {
+          uses = "actions/checkout@v4";
+          "with".ref = "\${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || '' }}";
+        }
+        {
+          uses = "haskell-actions/hackage-publish@v1";
+          "with" = {
+            hackageToken = "\${{ secrets.HACKAGE_AUTH_TOKEN }}";
+            packagesPath = "\${{ runner.temp }}/packages";
+            publish = false;
+          };
+        }
+      ];
+    };
+  };
+}

--- a/templates/haskell/.config/project/hlint.nix
+++ b/templates/haskell/.config/project/hlint.nix
@@ -1,12 +1,31 @@
-{lib, pkgs, ...}: {
+{
+  lib,
+  pkgs,
+  ...
+}: {
   ## Haskell linter
   programs.treefmt.programs.hlint.enable = true;
   ## TODO: Wrap this to find our generated hlint config in the store.
   project.devPackages = [pkgs.hlint];
   project.file.".hlint.yaml".text = lib.generators.toYAML {} [
-    {group = {name = "dollar"; enabled = true;};}
-    {group = {name = "future"; enabled = true;};}
-    {group = {name = "generalise"; enabled = true;};}
+    {
+      group = {
+        name = "dollar";
+        enabled = true;
+      };
+    }
+    {
+      group = {
+        name = "future";
+        enabled = true;
+      };
+    }
+    {
+      group = {
+        name = "generalise";
+        enabled = true;
+      };
+    }
 
     {ignore = {name = "Eta reduce";};}
     {ignore = {name = "Evaluate";};}
@@ -39,14 +58,54 @@
           "package traversable"
         ];
         rules = [
-          {warn = {lhs = "forM"; rhs = "for";};}
-          {warn = {lhs = "forM_"; rhs = "for_";};}
-          {warn = {lhs = "map"; rhs = "fmap";};}
-          {warn = {lhs = "mapM"; rhs = "traverse";};}
-          {warn = {lhs = "mapM_"; rhs = "traverse_";};}
-          {warn = {lhs = "return"; rhs = "pure";};}
-          {warn = {lhs = "sequence"; rhs = "sequenceA";};}
-          {warn = {lhs = "sequence_"; rhs = "sequenceA_";};}
+          {
+            warn = {
+              lhs = "forM";
+              rhs = "for";
+            };
+          }
+          {
+            warn = {
+              lhs = "forM_";
+              rhs = "for_";
+            };
+          }
+          {
+            warn = {
+              lhs = "map";
+              rhs = "fmap";
+            };
+          }
+          {
+            warn = {
+              lhs = "mapM";
+              rhs = "traverse";
+            };
+          }
+          {
+            warn = {
+              lhs = "mapM_";
+              rhs = "traverse_";
+            };
+          }
+          {
+            warn = {
+              lhs = "return";
+              rhs = "pure";
+            };
+          }
+          {
+            warn = {
+              lhs = "sequence";
+              rhs = "sequenceA";
+            };
+          }
+          {
+            warn = {
+              lhs = "sequence_";
+              rhs = "sequenceA_";
+            };
+          }
         ];
       };
     }
@@ -63,8 +122,18 @@
               note = "IncreasesLaziness";
             };
           }
-          {warn = {lhs = "mappend"; rhs = "(<>)";};}
-          {warn = {lhs = "(++)"; rhs = "(<>)";};}
+          {
+            warn = {
+              lhs = "mappend";
+              rhs = "(<>)";
+            };
+          }
+          {
+            warn = {
+              lhs = "(++)";
+              rhs = "(<>)";
+            };
+          }
         ];
       };
     }

--- a/templates/haskell/cabal.project
+++ b/templates/haskell/cabal.project
@@ -1,5 +1,9 @@
+flags:
+  -noisy-deprecations
+
 program-options
-  ghc-options: -Werror
+  ghc-options:
+    -Werror
 
 tests: True
 

--- a/templates/haskell/flake.nix
+++ b/templates/haskell/flake.nix
@@ -138,6 +138,7 @@
           "9.2.1"
           "9.4.1"
           "9.6.1"
+          "9.8.1" # since `cabal-plan-bounds` doesn’t work under Nix
         ];
 
         ## However, provide packages in the default overlay for _every_
@@ -154,7 +155,6 @@
             "ghc945"
             "ghc946"
             "ghc947"
-            "ghc948"
             "ghc963"
           ];
       };
@@ -182,7 +182,7 @@
         {default = self.devShells.${system}.${self.lib.defaultCompiler};}
         // concat.lib.mkDevShells
         pkgs
-        (self.lib.testedGhcVersions system)
+        (self.lib.supportedGhcVersions system)
         cabalPackages
         (hpkgs:
           [self.projectConfigurations.${system}.packages.path]

--- a/templates/haskell/planned-bounds.cabal
+++ b/templates/haskell/planned-bounds.cabal
@@ -1,0 +1,18 @@
+cabal-version: 3.4
+
+name: planned-bounds
+version: 0.1.0.0
+synopsis: Dependency bounds as determined by `cabal-plan-bounds`.
+description: This is a non-built package intended to catch changes in our
+             dependency bounds. The actual packages use slightly different
+             bounds in some cases (always accompanied by a comment), and a
+             clearer syntax (see cabal-plan-bounds#18). This allows us to still
+             have a check that fails and forces us to review changes without
+             having to match `cabal-plan-bounds`’ results exactly.
+
+library
+  build-depends:
+    Cabal ^>=3.0.0 || ^>=3.2.0 || ^>=3.4.0 || ^>=3.6.0 || ^>=3.8.0 || ^>=3.10.0,
+    base ^>=4.8.2 || ^>=4.9.0 || ^>=4.10.0 || ^>=4.11.0 || ^>=4.12.0 || ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0 || ^>=4.17.0 || ^>=4.18.0 || ^>=4.19.0,
+    cabal-doctest ^>=1.0.0,
+    doctest ^>=0.16.0 || ^>=0.17.0 || ^>=0.18.0 || ^>=0.19.0 || ^>=0.20.0 || ^>=0.21.0 || ^>=0.22.0,

--- a/templates/haskell/{{project.name}}/Setup.hs
+++ b/templates/haskell/{{project.name}}/Setup.hs
@@ -1,7 +1,16 @@
+-- __NB__: `custom-setup` doesn’t have any way to specify extensions or options,
+--         so any we want need to be specified here.
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE Unsafe #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Weverything #-}
+-- Warns even when `Unsafe` is explicit, not inferred. See
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/16689
+{-# OPTIONS_GHC -Wno-unsafe #-}
 
-module Main where
+module Main (main) where
 
+import safe "base" System.IO (IO)
 import "cabal-doctest" Distribution.Extra.Doctest (defaultMainWithDoctests)
 
 main :: IO ()

--- a/templates/haskell/{{project.name}}/tests/doctests.hs
+++ b/templates/haskell/{{project.name}}/tests/doctests.hs
@@ -1,8 +1,10 @@
+{-# LANGUAGE Unsafe #-}
+
 module Main (main) where
 
-import "base" Data.Function (($))
-import "base" Data.Semigroup (Semigroup ((<>)))
-import "base" System.IO (IO)
+import safe "base" Data.Function (($))
+import safe "base" Data.Semigroup (Semigroup ((<>)))
+import safe "base" System.IO (IO)
 import "doctest" Test.DocTest (doctest)
 import "this" Build_doctests (flags, module_sources, pkgs)
 

--- a/templates/haskell/{{project.name}}/{{project.name}}.cabal
+++ b/templates/haskell/{{project.name}}/{{project.name}}.cabal
@@ -1,7 +1,7 @@
 cabal-version:  3.0
 
 name:        {{project.name}}
-version:     {{project.version}}
+version:     0.1.0.0
 synopsis:    {{project.summary}}
 description: {{project.description}}
 author:      Greg Pfeil <greg@technomadic.org>
@@ -81,12 +81,37 @@ common GHC2021
     UnicodeSyntax
     NoExplicitNamespaces
 
+flag noisy-deprecations
+  description:
+    Prior to GHC 9.10, the `DEPRECATED` pragma can’t distinguish between terms
+    and types. Consenquently, you can get spurious warnings when there’s a name
+    collision and the name in the other namespace is deprecated. Or you can
+    choose to not get those warnings, at the risk of not being warned when
+    there’s a name collision and the namespace you’re referencing is the one
+    that’s deprecated.
+
 common defaults
   import: GHC2021
   build-depends:
     base ^>= {4.8.2, 4.9.0, 4.10.0, 4.11.0, 4.12.0, 4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0},
   ghc-options:
-    -Wall
+    -Weverything
+    -- If we didn’t allow inferred-safe imports, nothing would be `Safe`.
+    -Wno-inferred-safe-imports
+    -- Type inference good.
+    -Wno-missing-local-signatures
+    -- Warns even when `Unsafe` is explicit, not inferred. See
+    -- https://gitlab.haskell.org/ghc/ghc/-/issues/16689
+    -Wno-unsafe
+    -- `-trust` triggers this warning when applied to transitive dependencies
+    -Wno-unused-packages
+    -fpackage-trust
+    -trust base
+  if impl(ghc >= 8.10.1)
+    -- We support GHC versions without these features
+    ghc-options:
+      -Wno-missing-kind-signatures
+      -Wno-prepositive-qualified-module
   default-extensions:
     DefaultSignatures
     ExplicitNamespaces
@@ -99,7 +124,6 @@ common defaults
     -- QualifiedDo - uncomment if the oldest supported version is GHC 9.0.1+
     RecursiveDo
     -- RequiredTypeArguments - uncomment if the oldest supported version is GHC 9.10.1+
-    Safe
     -- StrictData - uncomment if the oldest supported version is GHC 8.0.1+
     -- TemplateHaskellQuotes - uncomment if the oldest supported version is GHC 8.0.1+
     TransformListComp
@@ -108,9 +132,13 @@ common defaults
     NoMonomorphismRestriction
     NoPatternGuards
     -- NoTypeApplications - uncomment if the oldest supported version is GHC 8.0.1+
+  if flag(noisy-deprecations)
+    cpp-options: -DSELLOUT_NOISY_DEPRECATIONS
 
 custom-setup
   setup-depends:
+    -- TODO: Remove `Cabal` dep once haskell/cabal#3751 is fixed.
+    Cabal ^>= {3.0.0, 3.2.0, 3.4.0, 3.6.0, 3.8.0, 3.10.0},
     base ^>= {4.8.2, 4.9.0, 4.10.0, 4.11.0, 4.12.0, 4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0},
     cabal-doctest ^>= 1.0.0,
 
@@ -125,5 +153,18 @@ test-suite doctests
   hs-source-dirs: tests
   main-is: doctests.hs
   build-depends:
-    doctest ^>= {0.15.0, 0.16.0, 0.17.0, 0.18.0, 0.19.0, 0.20.0, 0.21.0},
+    doctest ^>= {0.16.0, 0.17.0, 0.18.0, 0.19.0, 0.20.0, 0.21.0, 0.22.0},
     {{project.name}},
+  -- TODO: The sections below here are necessary because we don’t have control
+  --       over the generated `Build_doctests.hs` file. So we have to silence
+  --       all of its warnings one way or another.
+  ghc-options:
+    -Wno-missing-deriving-strategies
+    -Wno-missing-export-lists
+    -Wno-missing-import-lists
+    -Wno-safe
+  default-extensions:
+    -- Since we can’t add `{-# LANGUAGE Safe -#}` to the generated
+    -- “Build_doctests.hs”, we set it here, and that means it has to match
+    -- doctests.hs, which is `Unsafe`.
+    Unsafe


### PR DESCRIPTION
- publishes to Hackage on tag
- fewer garnix builds (due to new 100 build constraint) – only builds “all” package for each GHC version
- no longer expects `package.version` in the Mustache file
- corrects set of required checks
- disables FlakeHub (which doesn’t allow IFD)
- runs `cabal-plan-bounds` across builds
- enables `-Weverything`
- uses Safe Haskell