### PR TITLE
Remove templated versions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
       ## This ensures that we explicitly list all the platforms we support while
       ## protecting against changes in `defaultSystems` (removing a system from
       ## `defaultSystems` shouldn’t remove it from here, but one being added
-      ## should alert us to any failures.
+      ## should alert us to any failures).
       nixpkgs.lib.unique
       (flake-utils.lib.defaultSystems
         ++ [

--- a/templates/bash/flake.nix
+++ b/templates/bash/flake.nix
@@ -66,7 +66,7 @@
           (pkgs.stdenv.mkDerivation {
             inherit pname src;
 
-            version = "{{project.version}}";
+            version = "0.1.0";
 
             meta = {
               description = "{{project.summary}}";

--- a/templates/c/.config/project/clang-format.nix
+++ b/templates/c/.config/project/clang-format.nix
@@ -84,18 +84,18 @@ in {
     #     However, here we only categorize the parts that can be identified syntactically. Any
     #     sub-ordering would be project-specific.
     IncludeCategories = [
-      { # system
+      {
         Regex = "<[^/.]+>";
         Priority = 3;
-      }
-      { # third-party
+      } # system
+      {
         Regex = "<.*>";
         Priority = 2;
-      }
-      { # local
+      } # third-party
+      {
         Regex = ".*";
         Priority = 1;
-      }
+      } # local
     ];
     IndentAccessModifiers = true; # consistent
     IndentCaseBlocks = true; # consistent, case blocks aren’t blocks, they only scope, so don’t format like blocks
@@ -172,10 +172,9 @@ in {
     SpacesInCStyleCastParentheses = false; # consistent
     SpacesInContainerLiterals = false; # consistent
     SpacesInLineCommentPrefix = {
-      # consistent
       Minimum = 1;
       Maximum = 1;
-    };
+    }; # consistent
     SpacesInParentheses = false; # consistent
     SpacesInSquareBrackets = false; # consistent
     Standard = "c++20";

--- a/templates/c/configure.ac
+++ b/templates/c/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([{{project.name}}], [{{project.version}}], [greg@technomadic.org])
+AC_INIT([{{project.name}}], [0.1.0], [greg@technomadic.org])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 
 AC_PROG_CXX

--- a/templates/c/flake.nix
+++ b/templates/c/flake.nix
@@ -70,7 +70,7 @@
               pkgs.autoreconfHook
             ];
 
-            version = "{{project.version}}";
+            version = "0.1.0";
           });
       };
 

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -62,7 +62,7 @@
           (pkgs.stdenv.mkDerivation {
             inherit pname src;
 
-            version = "{{project.version}}";
+            version = "0.1.0";
           });
       };
 

--- a/templates/example.yaml
+++ b/templates/example.yaml
@@ -5,7 +5,6 @@
       name: "template-example",
       repo: "sellout/system-configurations",
       summary: "An example template instantiation",
-      version: "0.1.0",
     },
   type: { name: "Whitespace" },
 }

--- a/templates/nix/flake.nix
+++ b/templates/nix/flake.nix
@@ -62,7 +62,7 @@
           (pkgs.stdenv.mkDerivation {
             inherit pname src;
 
-            version = "{{project.version}}";
+            version = "0.1.0";
           });
       };
 


### PR DESCRIPTION
The template fields should represent things that don’t change over time (so we can re-run it when we update the templates).

Versions are not like this – they always start with the same value (so there’s no benefit to a template in the first place), and they are expected to change.