### PR TITLE
Enable automerge for Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.renovatebot.com/renovate-schema.json","extends":["config:base"],"lockFileMaintenance":{"enabled":true},"nix":{"enabled":true}}
+{"$schema":"https://docs.renovatebot.com/renovate-schema.json","extends":["config:base"],"lockFileMaintenance":{"automerge":false,"enabled":true},"nix":{"enabled":true},"packageRules":{"_type":"if","condition":false,"content":[{"automerge":true,"matchCurrentVersion":"!/^0/","matchUpdateTypes":["minor","patch"]}]}}


### PR DESCRIPTION
So frustrating to have to go through every PR manually. Since we now check project-manager-files in CI, this should be pretty safe. It only auto-merges if there are no checks that wouldn’t be run in CI.