### PR TITLE
Fix bug introduced with Renovate automerging

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.renovatebot.com/renovate-schema.json","extends":["config:base"],"lockFileMaintenance":{"automerge":false,"enabled":true},"nix":{"enabled":true},"packageRules":{"_type":"if","condition":false,"content":[{"automerge":true,"matchCurrentVersion":"!/^0/","matchUpdateTypes":["minor","patch"]}]}}
+{"$schema":"https://docs.renovatebot.com/renovate-schema.json","extends":["config:base"],"lockFileMaintenance":{"automerge":false,"enabled":true},"nix":{"enabled":true},"packageRules":[]}

--- a/base/.config/project/renovate.nix
+++ b/base/.config/project/renovate.nix
@@ -12,14 +12,17 @@
       inherit automerge;
       enabled = true;
     };
-    packageRules = lib.mkIf automerge [
-      {
-        automerge = true;
-        ## Don’t automerge updates of pre-release software.
-        matchCurrentVersion = "!/^0/";
-        ## Only automerge non-major version updates.
-        matchUpdateTypes = ["minor" "patch"];
-      }
-    ];
+    packageRules =
+      if automerge
+      then [
+        {
+          automerge = true;
+          ## Don’t automerge updates of pre-release software.
+          matchCurrentVersion = "!/^0/";
+          ## Only automerge non-major version updates.
+          matchUpdateTypes = ["minor" "patch"];
+        }
+      ]
+      else [];
   };
 }


### PR DESCRIPTION
Need to use `if` not `mkIf` to ensure we generate a JSON array in every case.

Fixes #75.