### PR TITLE
Use `overrideScope` instead of `overrideScope'`

### DIFF
--- a/nix/elisp-dependencies.nix
+++ b/nix/elisp-dependencies.nix
@@ -1,6 +1,6 @@
 final: prev: {
   emacsPackagesFor = emacs:
-    (prev.emacsPackagesFor emacs).overrideScope' (efinal: eprev: {
+    (prev.emacsPackagesFor emacs).overrideScope (efinal: eprev: {
       # The `eldev` package doesn’t expose the executable.
       eldev = eprev.eldev.overrideAttrs (old: {
         postInstall = ''

--- a/nix/lib/elisp.nix
+++ b/nix/lib/elisp.nix
@@ -110,7 +110,7 @@ in {
 
   overlays.default = emacsOverlay: final: prev: {
     emacsPackagesFor = emacs:
-      (prev.emacsPackagesFor emacs).overrideScope'
+      (prev.emacsPackagesFor emacs).overrideScope
       (emacsOverlay final prev);
   };
 

--- a/templates/emacs-lisp/.config/project/default.nix
+++ b/templates/emacs-lisp/.config/project/default.nix
@@ -67,7 +67,7 @@
     (flaky.lib.forGarnixSystems supportedSystems (sys: [
       "check elisp-doctor [${sys}]"
       "check elisp-lint [${sys}]"
-      "homeConfig ${sys}-${config.project.name}-example"
+      "homeConfig ${sys}-example"
       "package default [${sys}]"
       "package emacs-${config.project.name} [${sys}]"
       ## FIXME: These are duplicated from the base config

--- a/templates/emacs-lisp/README.org
+++ b/templates/emacs-lisp/README.org
@@ -1,8 +1,8 @@
 #+title: {{project.name}}
 
-[[https://garnix.io][https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}}]]
-[[https://repology.org/project/{{project.name}}/versions][https://repology.org/badge/tiny-repos/{{project.name}}.svg]]
-[[https://repology.org/project/{{project.name}}/versions][https://repology.org/badge/latest-versions/{{project.name}}.svg]]
+[[https://garnix.io][https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2Femacs-{{project.name}}]]
+[[https://repology.org/project/emacs-{{project.name}}/versions][https://repology.org/badge/tiny-repos/emacs-{{project.name}}.svg]]
+[[https://repology.org/project/emacs-{{project.name}}/versions][https://repology.org/badge/latest-versions/emacs-{{project.name}}.svg]]
 
 {{project.summary}}
 


### PR DESCRIPTION
Nixpkgs 24.11 has renamed this, so any downstream Elisp project is now warning about the rename. This updates it, so no more warning.