### PR TITLE
Updates to the Haskell template

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,10 +53,10 @@
 
         dependencies = final: prev: {
           haskellPackages =
-            prev.haskellPackages.extend (self.overlays.haskell-dependencies final prev);
+            prev.haskellPackages.extend (self.overlays.haskellDependencies final prev);
         };
 
-        haskell-dependencies = import ./nix/haskell-dependencies.nix;
+        haskellDependencies = import ./nix/haskell-dependencies.nix;
       };
 
       lib = import ./nix/lib.nix {

--- a/nix/haskell-dependencies.nix
+++ b/nix/haskell-dependencies.nix
@@ -4,17 +4,214 @@
 ### Tests should be disabled as tightly as possible, but we should try to use
 ### the same version of a package across all systems & compilers.
 final: prev: hfinal: hprev:
+(
+  if final.lib.versionAtLeast hprev.ghc.version "9.10.0"
+  then {
+    ChasingBottoms =
+      final.haskell.lib.overrideCabal
+      hprev.ChasingBottoms {
+        editedCabalFile = "PsuYWFTvDZ5jwqiBwsMF8OYZyPFQCRWL4XARvF+0zYo=";
+        revision = "1";
+        sha256 = "vuzRlfSR/RcjYgXQD4gu521r2Re/EENQ31enBeyJt2Y=";
+      };
+    ## Earlier versions are too restrictive on `base`.
+    base64 = final.haskell.lib.overrideCabal hprev.base64 {
+      editedCabalFile = null;
+      sha256 = "eUIjnxgElF/W0xmpU/JsU7ZFGAds0pQUH9qYPy/xsrY=";
+      version = "1.0";
+    };
+    ## Earlier versions are too restrictive on `base`.
+    boring = hfinal.boring_0_2_2;
+    ## Earlier versions are too restrictive on `base`.
+    cabal-doctest =
+      final.haskell.lib.overrideCabal
+      hprev.cabal-doctest {
+        editedCabalFile = null;
+        sha256 = "gcrQ/EhhVyncvuw+zRK7QpdX8pmsrRS5LvC5VxA+lNM=";
+        version = "1.0.10";
+      };
+    ## This is the latest version, but test suites fail (and also fail
+    ## on older versions).
+    call-stack = final.haskell.lib.dontCheck hprev.call-stack;
+    ## Earlier versions are too restrictive on `base`.
+    co-log-core = final.haskell.lib.overrideCabal hprev.co-log-core {
+      editedCabalFile = null;
+      sha256 = "97JhkWrdYPZRq8bxcEAqbnUELuRIj5SkCtiKlxpxzcc=";
+      version = "0.3.2.2";
+    };
+    ## Earlier versions are too restrictive on `base`.
+    commutative-semigroups =
+      final.haskell.lib.overrideCabal
+      hprev.commutative-semigroups {
+        editedCabalFile = null;
+        patches = [];
+        sha256 = "4uBVoGWG581YoVWw2j4NSdjMBvuUH6qNFMGuVo33ttw=";
+        version = "0.2.0.1";
+      };
+    ## Earlier versions fail tests and are too restrictive on `ghc`.
+    doctest = final.haskell.lib.overrideCabal hprev.doctest {
+      editedCabalFile = null;
+      sha256 = "4r/FouY3sgfbFhbkiAKNm4PoXXdJ20G0bmamgKVGSFw=";
+      version = "0.22.3";
+    };
+    ## Earlier versions are too restrictive on `Cabal`.
+    doctest-parallel =
+      final.haskell.lib.overrideCabal
+      hprev.doctest-parallel {
+        editedCabalFile = "VaheuX8Cjum8iJYRFVnwTaACnFlxD59L76KRHUn8VNA=";
+        revision = "1";
+        sha256 = "ik95fZ8ZWswN5z52OF2xMERQOixCXH0ExHoTAYAA8/Y=";
+      };
+    ## Earlier versions are too restrictive on `base`.
+    extensions = final.haskell.lib.overrideCabal hprev.extensions {
+      editedCabalFile = null;
+      sha256 = "7Z1GRTIaDmkf5CKyk9HiUJ+zYX7XgPqo2SwOprPDQeU=";
+      version = "0.1.0.2";
+    };
+    ## Earlier versions are too restrictive on `base`.
+    ghc-trace-events =
+      final.haskell.lib.overrideCabal
+      hprev.ghc-trace-events {
+        editedCabalFile = null;
+        sha256 = "6afff442G4ouUJsYB0B8RlTxanNWQtVOhcjJQ/5B0wU=";
+        version = "0.1.2.9";
+      };
+    ## This is the version for this compiler.
+    ghc-lib-parser =
+      final.haskell.lib.overrideCabal
+      hprev.ghc-lib-parser {
+        editedCabalFile = null;
+        sha256 = "N9HfXP5D3USDxl3FfFIs2wRsju3cu/2MyqW/5bDW8Tk=";
+        version = "9.10.1.20240511";
+      };
+    ## Otherwise `hashable` picks up a version of `os-string`
+    ## different from GHC’s.
+    hashable = hprev.hashable.override {os-string = null;};
+    ## Earlier revisions are too restrictive on `containers` &
+    ## `template-haskell`.
+    hedgehog = final.haskell.lib.overrideCabal hprev.hedgehog {
+      editedCabalFile = "2Lyqz+kAo0cEa8fDBHtZaR+NRdO4B1U7xOwEvE4R2oE=";
+      revision = "7";
+      sha256 = "9Ur7MVUuD4CQML7K00nL/hmmV1OneHcdxzFLKmxB5us=";
+    };
+    ## Earlier revisions are too restrictive on `base`.
+    hie-compat = final.haskell.lib.overrideCabal hprev.hie-compat {
+      editedCabalFile = "dKhYWpDjwGZnE0k5zRcM/yQGfVqYjhSCl4WvDfpr0Q8=";
+      revision = "1";
+      sha256 = "FWhmEEEOQePe2SpFICK03C8JSFg/HgJg36NhID4QBVQ=";
+    };
+    ## Earlier versions are too restrictive on `base` & `containers`.
+    indexed-traversable = hfinal.indexed-traversable_0_1_4;
+    ## Earlier versions are too restrictive on `base`.
+    indexed-traversable-instances =
+      final.haskell.lib.overrideCabal
+      hprev.indexed-traversable-instances {
+        editedCabalFile = null;
+        sha256 = "PCu2L7oUHWaWF3Bw1juIvFaxlLxg9rc9ImOwJE4vx8E=";
+        version = "0.1.2";
+      };
+    ## Earlier versions are too restrictive on `template-haskell`.
+    lens = final.haskell.lib.overrideCabal hprev.lens {
+      editedCabalFile = "idtM1SHdX8+taKDMjgAiFrkl8z92YACWiWhDM6zW3nA=";
+      revision = "1";
+      sha256 = "rCvzV0tzK3Tq5W0f2a+uaSt/HFmFMgrOJfGmrVwbccw=";
+      version = "5.3";
+    };
+    ## `Control.Monad.Trans.List` is gone as of GHC 9.8, but
+    ## `lifted-base` hasn’t updated its tests to avoid it.
+    lifted-base = final.haskell.lib.dontCheck hprev.lifted-base;
+    ## There is no release that supports base 4.20 yet.
+    lucid = final.haskell.lib.doJailbreak hprev.lucid;
+    ## Earlier revisions are too restrictive on `base`.
+    nothunks = final.haskell.lib.overrideCabal hprev.nothunks {
+      editedCabalFile = "JDJOr7UEoAvZwDSFUEFkGfsPoFXStypqzx6b5eCZhBE=";
+      revision = "1";
+      sha256 = "nHwKOFIRxdFCfbFWiWpW/AWwN01XXEKaHHoJ88ojveg=";
+    };
+    ## This version is too restrictive on `base`, but later versions
+    ## lead to infinite recursion.
+    # primitive = final.haskell.lib.doJailbreak hprev.primitive;
+    ## Earlier versions are too restrictive on `base`.
+    primitive = final.haskell.lib.overrideCabal hprev.primitive {
+      editedCabalFile = "LgjFQJ41WcfxZp71DpoNmjl+aOz1ERDV4s7fBc3X2Tw=";
+      revision = "1";
+      sha256 = "aW1L0pHJTXNhQtYYIRfcpCWNPvKL/v22SayLXs0Jmcc=";
+      version = "0.9.0.0";
+    };
+    ## Earlier versions are too restrictive on `base` & `containers`.
+    quickcheck-instances =
+      final.haskell.lib.overrideCabal
+      hprev.quickcheck-instances {
+        editedCabalFile = null;
+        sha256 = "mxh+Gvk1Hf3CF+oCdDOtGd5oajZl4oznlwMixp2BTi8=";
+        version = "0.3.31";
+      };
+    ## Earlier versions are too restrictive on `base`, `containers`, &
+    ## `template-haskell`.
+    scientific = final.haskell.lib.overrideCabal hprev.scientific {
+      editedCabalFile = null;
+      sha256 = "E7NDvKiqJtdxjlLmIuWhGAVmU+2vy8fMxTM75yFyGM8=";
+      version = "0.3.8.0";
+    };
+    ## Earlier versions are too restrictive on `containers` &
+    ## `template-haskell`.
+    th-abstraction =
+      final.haskell.lib.overrideCabal
+      hprev.th-abstraction {
+        editedCabalFile = "MTdg1jCFGg66a9yxoetUPEycWDBy1wQGf6MkilJSqK4=";
+        revision = "2";
+        sha256 = "aepuyh8MALbh4fgynJCOx25zhV4s5ukazi+Lv5LFGjA=";
+        version = "0.6.0.0";
+      };
+    ## Earlier versions are too restrictive on `base`.
+    these = final.haskell.lib.overrideCabal hprev.these {
+      editedCabalFile = null;
+      sha256 = "F9bZMzZe2r+AGhaELBQDvdN8xTAPqi/MqYDezasi5N4=";
+      version = "1.2.1";
+    };
+    ## Earlier versions are too restrictive on `base`, and tests
+    ## depend on a too-old version of `tasty`.
+    time-compat = final.haskell.lib.overrideCabal hprev.time-compat {
+      doCheck = false;
+      editedCabalFile = null;
+      sha256 = "yY++oh0DbDJjrxht8FabhCXIetNTsCE1N5R0Pk5jHcw=";
+      version = "1.9.7";
+    };
+    ## Earlier revisions are too restrictive on `base`.
+    unliftio-core =
+      final.haskell.lib.overrideCabal
+      hprev.unliftio-core {
+        editedCabalFile = "9qJzb4WLU5DZOE3KQ9PqTZbpyhchd5F5HKSVG6boByo=";
+        revision = "4";
+        sha256 = "mThMuo1W2dYbheOKMTqT6823i+ZWY2fwkw71gFl/4+M=";
+      };
+    ## Earlier versions are too restrictive on `template-haskell`.
+    uuid-types = final.haskell.lib.overrideCabal hprev.uuid-types {
+      editedCabalFile = null;
+      sha256 = "fg3ZU0g9b9PKSbyu1rEfnjwnhyE0ebJYHgd0eDa4NX4=";
+      version = "1.0.6";
+    };
+  }
+  else {}
+)
 ## TODO: Various packages fail their tests on i686-linux. Should probably fix
 ##       them at some point.
-if final.system == "i686-linux"
-then {
-  #     enummapset = final.haskell.lib.dontCheck hprev.enummapset;
-  hackage-security = final.haskell.lib.dontCheck hprev.hackage-security;
-  persistent = final.haskell.lib.dontCheck hprev.persistent;
-  #     sqlite-simple = final.haskell.lib.dontCheck hprev.sqlite-simple;
-  unordered-containers =
-    final.haskell.lib.dontCheck
-    hprev.unordered-containers;
-  validity = final.haskell.lib.dontCheck hprev.validity;
-}
-else {}
+// (
+  if final.system == "i686-linux"
+  then {
+    aeson = final.haskell.lib.dontCheck hprev.aeson;
+    enummapset = final.haskell.lib.dontCheck hprev.enummapset;
+    ## Tests run out of memory (at least on garnix)
+    generic-arbitrary = final.haskell.lib.dontCheck hprev.generic-arbitrary;
+    hackage-security = final.haskell.lib.dontCheck hprev.hackage-security;
+    persistent = final.haskell.lib.dontCheck hprev.persistent;
+    relude = final.haskell.lib.dontCheck hprev.relude;
+    slist = final.haskell.lib.dontCheck hprev.slist;
+    ## Stack smashing
+    sqlite-simple = final.haskell.lib.dontCheck hprev.sqlite-simple;
+    unordered-containers =
+      final.haskell.lib.dontCheck hprev.unordered-containers;
+    validity = final.haskell.lib.dontCheck hprev.validity;
+  }
+  else {}
+)

--- a/templates/haskell/README.md
+++ b/templates/haskell/README.md
@@ -24,7 +24,7 @@ This command ensures that any work you do within this repository is done within 
 
 This will apply our repository-specific Git configuration to `git` commands run against this repository. It’s lightweight (you should definitely look at it before applying this command) – it does things like telling `git blame` to ignore formatting-only commits.
 
-## building & development
+## building
 
 Especially if you are unfamiliar with the {{type.name}} ecosystem, there is a Nix build (both with and without a flake). If you are unfamiliar with Nix, [Nix adjacent](...) can help you get things working in the shortest time and least effort possible.
 
@@ -38,24 +38,59 @@ Especially if you are unfamiliar with the {{type.name}} ecosystem, there is a Ni
 
 This project is built with [Cabal](https://cabal.readthedocs.io/en/stable/index.html). Individual packages will work with older versions, but ./cabal.package requires Cabal 3.6+.
 
-## versioning
+## development
 
-In the absolute, almost every change is a breaking change. This section describes how we mitigate that to provide minor updates and revisions.
+### CI failures
 
-Here are some common changes that can have unintended effects:
+There are a few jobs that may fail during CI and indicate specific changes that need to be made to your PR. If you run into any failures other than those that are listed here, they likely have remedies that are specific to your changes. If you need help replicating or resolving them, or think that they represent general patterns like the ones listed below, inform the maintainers. They can help you resolve them and decide if they should be called out with generic resolution processes.
 
-- adding instances can conflict with downstream orphans,
-- adding a module can conflict with a module from another package,
-- adding a definition to an existing module can conflict if there are unqualified imports, and
-- even small bugfixes can introduce breaking changes where downstream depended on the broken results.
+#### CI / check-bounds (step: check if bounds have changed)
 
-To mitigate some of those issues for versioning, we assume the following usage:
+A failure in the “check if bounds have changed” step indicates that the bounds on direct dependencies have changed.
 
-- modules should be imported using `PackageImports`, so that adding modules is a _minor_ change;
-- modules should be imported qualified, so that adding definitions is a _minor_ change;
-- adding instances can't be mitigated in the same way, and it's not uncommon for downstream libraries to add orphans instances when they're omitted from upstream libraries. However, since these conflicts can only happen via direct dependencies, and represent an explicit downstream workaround, it’s reasonable to expect a quick downstream update to remove or conditionalize the workaround. So, this is considered a _minor major_ change;
-- deprecation is considered a _revision_ change, however it will often be paired with _minor_ changes. `-Werror` can cause this to fail, but published libraries shouldn't be compiled with `-Werror`.
+It currently means that the discovered bounds have been restricted, which is always a breaking change. Unfortunately, this is sometimes not due to anything in the PR, but it does indicate we’re no longer testing the versions we used to – the Cabal solver will sometimes start choosing different packages, depending on releases. Due to the behavior of the solver, the most likely ones to change are in the middle of the range. There are a few ways to address this problem:
+
+1. Simply change the bounds as the output recommends, and make sure the PR bumps the major version number. If this change is already bumping the major version, this is probably the right choice to make.
+2. Try to force Cabal to try the previous bounds. If you had manually changed the bounds because you needed some new feature, is it possible to conditionalize use of that feature so that we can also still use and test with older bounds?
+3. Tell CI that you want to keep the bounds the same even though they’re not tested. You do this by adding the old bound to the `extraDependencyVersions` list in flake.nix. This should be done carefully, but one use case is where those bounds _are_ tested by the Nix builds, but not by GitHub.
+
+#### CI / check-licenses (step: check if licenses have changed)
+
+This means there has _possibly_ been some change in the licensing, but it is not foolproof. This only captures the licensing for one particular Cabal solution, so other solutions may have different transitive dependencies or licenses.
+
+If there is a new license type in the list, it could affect how consumers of this can use our library. If the new license is not compatible with the existing set, then that is a breaking change. If a package has changed its license, then we can alternatively restrict that package to versions that only use the previous license. Since making a license more restrictive introduces incompatibilities, this should only happen when they bump their major version, but there is no guarantee. In that case, this should just prevent us from extending the bounds, which is fine. But if it requires restricting bounds at the minor or revision level, then that is still a breaking change on our side. Ideally we wouldn’t have to restrict that, but just make sure the consumer is informed about the license change and how to avoid it, but I don’t know how to convey that yet.
+
+If there is a new dependency that has appeared, that should already be reflected in a major version bump. However, not all libraries introduce a major version bump when they add a dependency, and supporting wider version ranges means we may pick up a new dependency without excluding solutions that don’t involve that dependency.
+
+It is tempting to think that moving a dependency from the transitive list to the direct list doesn’t involve a version bump, but that is not necessarily true. First, the transitive dependency must exist on all possible dependency solutions for that to be true. Then, it is also possible for a new revision of a library to _remove_ dependencies, which means they will no longer appear in the transitive graph, invalidating our previous assumption. For this reason, we shouldn’t treat a move from transitive to direct as any different from a new dependency.
+
+#### check formatter
+
+There is some unformatted code (or perhaps some lint that needs addressing). If you use Nix, running `nix fmt` should automatically fix most of the formatting, and at least report additional lint that needs addressing.
+
+If you don’t use Nix, the CI log should contain some lines like
+
+```
+treefmt 0.6.1
+[INFO ] #alejandra: 1 files processed in 43.00ms
+[INFO ] #prettier: 7 files processed in 423.85ms
+[INFO ] #ormolu: 39 files processed in 1.60s
+[INFO ] #hlint: 39 files processed in 2.15s
+0 files changed in 2s (found 66, matched 86, cache misses 86)
+```
+
+Those `INFO` lines indicate which formatters were run. Running those same ones individually should address the issues. You can also just indicate in your PR that you don’t use Nix, and a maintainer will happily fix the formatting for you.
+
+This implies a revision bump in any package that has been reformatted, as well as a revision bump in the repository.
+
+#### check project-manager-files
+
+Some files committed to the repository don’t match the ones that would be generated by Project Manager. This can happen either because you modified some of the Nix project configuration and forgot to regenerate the files, or because you edited generated files directly rather than editing the Nix project configuration.
+
+If you use Nix, running `project-manager switch` from a project dev shell (or `nix run github:sellout/project-manager -- switch`) anywhere should fix this (although check to see if you lost intentional changes to generated files, and add them via the Nix project configuration instead).
+
+If you don’t use Nix, you will need to mention that in your PR so that one of the maintainers can resolve this for you.
 
 ## comparisons
 
-Other projects similar to this one, and how they differ.
+See [the package README](./{{project.name}}/README.md) for comparisons with other similar projects.

--- a/templates/haskell/{{project.name}}/CHANGELOG.md
+++ b/templates/haskell/{{project.name}}/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog 1.1](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## [0.1.0.0] - {{project.creation-date}}
+
+### Added
+
+- initial release of this package
+
+[0.1.0.0]: https://github.com/{{project.repo}}/releases/tag/v0..1.0.0

--- a/templates/haskell/{{project.name}}/README.md
+++ b/templates/haskell/{{project.name}}/README.md
@@ -10,6 +10,104 @@
 
 ## usage
 
+## versioning
+
+This project largely follows the [Haskell Package Versioning Policy](https://pvp.haskell.org/) (PVP), but is more strict in some ways.
+
+The version always has four components, `A.B.C.D`. The first three correspond to those required by PVP, while the fourth matches the “patch” component from [Semantic Versioning](https://semver.org/).
+
+Here is a breakdown of some of the constraints:
+
+### sensitivity to additions to the API
+
+PVP recommends that clients follow [these import guidelines](https://wiki.haskell.org/Import_modules_properly) in order that they may be considered insensitive to additions to the API. However, this isn’t sufficient. We expect clients to follow these additional recommendations for API insensitivity
+
+If you don’t follow these recommendations (in addition to the ones made by PVP), you should ensure your dependencies don’t allow a range of `C` values. That is, your dependencies should look like
+
+```cabal
+yaya >=1.2.3 && <1.2.4
+```
+
+rather than
+
+```cabal
+yaya >=1.2.3 && <1.3
+```
+
+#### use package-qualified imports everywhere
+
+If your imports are [package-qualified](https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/package_qualified_imports.html?highlight=packageimports#extension-PackageImports), then a dependency adding new modules can’t cause a conflict with modules you already import.
+
+#### avoid orphans
+
+Because of the transitivity of instances, orphans make you sensitive to your dependencies’ instances. If you have an orphan instance, you are sensitive to the APIs of the packages that define the class and the types of the instance.
+
+One way to minimize this sensitivity is to have a separate package (or packages) dedicated to any orphans you have. Those packages can be sensitive to their dependencies’ APIs, while the primary package remains insensitive, relying on the tighter ranges of the orphan packages to constrain the solver.
+
+### transitively breaking changes (increments `A`)
+
+#### removing a type class instance
+
+Type class instances are imported transitively, and thus changing them can impact packages that only have your package as a transitive dependency.
+
+#### widening a dependency range with new major versions
+
+This is a consequence of instances being transitively imported. A new major version of a dependency can remove instances, and that can break downstream clients that unwittingly depended on those instances.
+
+A library MAY declare that it always bumps the `A` component when it removes an instance (as this policy dictates). In that case, only `A` widenings need to induce `A` bumps. `B` widenings can be `D` bumps like other widenings, Alternatively, one may compare the APIs when widening a dependency range, and if no instances have been removed, make it a `D` bump.
+
+### breaking changes (increments `B`)
+
+#### restricting an existing dependency’s version range in any way
+
+Consumers have to contend not only with our version bounds, but also with those of other libraries. It’s possible that some dependency overlapped in a very narrow way, and even just restricting a particular patch version of a dependency could make it impossible to find a dependency solution.
+
+#### restricting the license in any way
+
+Making a license more restrictive may prevent clients from being able to continue using the package.
+
+#### adding a dependency
+
+A new dependency may make it impossible to find a solution in the face of other packages dependency ranges.
+
+### non-breaking changes (increments `C`)
+
+#### adding a module
+
+This is also what PVP recommends. However, unlike in PVP, this is because we recommend that package-qualified imports be used on all imports.
+
+### other changes (increments `D`)
+
+#### widening a dependency range for non-major versions
+
+This is fairly uncommon, in the face of `^>=`-style ranges, but it can happen in a few situations.
+
+#### deprecation
+
+**NB**: This case is _weaker_ than PVP, which indicates that packages should bump their major version when adding `deprecation` pragmas.
+
+We disagree with this because packages shouldn’t be _publishing_ with `-Werror`. The intent of deprecation is to indicate that some API _will_ change. To make that signal a major change itself defeats the purpose. You want people to start seeing that warning as soon as possible. The major change occurs when you actually remove the old API.
+
+Yes, in development, `-Werror` is often (and should be) used. However, that just helps developers be aware of deprecations more immediately. They can always add `-Wwarn=deprecation` in some scope if they need to avoid updating it for the time being.
+
+-------
+
+In the absolute, almost every change is a breaking change. This section describes how we mitigate that to provide minor updates and revisions.
+
+Here are some common changes that can have unintended effects:
+
+- adding instances can conflict with downstream orphans,
+- adding a module can conflict with a module from another package,
+- adding a definition to an existing module can conflict if there are unqualified imports, and
+- even small bugfixes can introduce breaking changes where downstream depended on the broken results.
+
+To mitigate some of those issues for versioning, we assume the following usage:
+
+- modules should be imported using `PackageImports`, so that adding modules is a _minor_ change;
+- modules should be imported qualified, so that adding definitions is a _minor_ change;
+- adding instances can't be mitigated in the same way, and it's not uncommon for downstream libraries to add orphans instances when they're omitted from upstream libraries. However, since these conflicts can only happen via direct dependencies, and represent an explicit downstream workaround, it’s reasonable to expect a quick downstream update to remove or conditionalize the workaround. So, this is considered a _minor major_ change;
+- deprecation is considered a _revision_ change, however it will often be paired with _minor_ changes. `-Werror` can cause this to fail, but published libraries shouldn't be compiled with `-Werror`.
+
 ## licensing
 
 This package is licensed under [The GNU AGPL 3.0 or later](./LICENSE). If you need a license for usage that isn’t covered under the AGPL, please contact [Greg Pfeil](mailto:greg@technomadic.org?subject=licensing%20no-recursion).

--- a/templates/haskell/{{project.name}}/{{project.name}}.cabal
+++ b/templates/haskell/{{project.name}}/{{project.name}}.cabal
@@ -15,23 +15,24 @@ license: AGPL-3.0-or-later
 license-files:
   LICENSE
 extra-doc-files:
+  CHANGELOG.md
+  README.md
   docs/*
 tested-with:
   GHC == {
---  GHCup   Nixpkgs
     7.10.3,
     8.0.2,
     8.2.2,
     8.4.1,
     8.6.1,
-    8.8.1,  8.8.4,
+    8.8.1, 8.8.4,
     8.10.1, 8.10.7,
-    9.0.1,  9.0.2,
-    9.2.1,  9.2.5,
-    9.4.1,  9.4.5,
-    9.6.1,  9.6.3,
-            9.8.1,
-            9.10.1,
+    9.0.1, 9.0.2,
+    9.2.1, 9.2.5,
+    9.4.1, 9.4.5,
+    9.6.1, 9.6.3,
+    9.8.1,
+    9.10.1
   }
 
 source-repository head


### PR DESCRIPTION
- Many new Haskell packages updated to work with GHC 9.10.1. Hopefully these won’t be necessary soon.
- Added `macos-14` to `githubSystems`.
- Make github-ci.nix a bit more flexible.
- Added a README section on dealing with CI failures.
- Add a CHANGELOG.md to the package directory.
- Move the versioning description to the package directory (and update it).
- Various other smaller fixes.