### PR TITLE
Update links to garnix builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flaky templates & `devShells`
 
-[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2Fflaky)](https://garnix.io)
+[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2Fflaky)](https://garnix.io/repo/sellout/flaky)
 
 Templates for Sellout’s personal projects, plus a flake `lib` to make the templates as lightweight and easy to keep in sync as possible.
 

--- a/templates/bash/README.md
+++ b/templates/bash/README.md
@@ -1,6 +1,6 @@
 # {{project.name}}
 
-[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io)
+[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io/repo/{{project.repo}})
 
 {{project.summary}}
 

--- a/templates/c/README.md
+++ b/templates/c/README.md
@@ -1,6 +1,6 @@
 # {{project.name}}
 
-[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io)
+[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io/repo/{{project.repo}})
 
 {{project.summary}}
 

--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -1,6 +1,6 @@
 # {{project.name}}
 
-[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io)
+[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io/repo/{{project.repo}})
 
 {{project.summary}}
 

--- a/templates/dhall/README.md
+++ b/templates/dhall/README.md
@@ -1,6 +1,6 @@
 # {{project.name}}
 
-[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io)
+[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io/repo/{{project.repo}})
 
 {{project.summary}}
 

--- a/templates/haskell/README.md
+++ b/templates/haskell/README.md
@@ -1,8 +1,6 @@
 # {{project.name}}
 
-[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io)
-[![Packaging status](https://repology.org/badge/tiny-repos/haskell:{{project.name}}.svg)](https://repology.org/project/haskell:{{project.name}}/versions)
-[![latest packaged versions](https://repology.org/badge/latest-versions/haskell:{{project.name}}.svg)](https://repology.org/project/haskell:{{project.name}}/versions)
+[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io/repo/{{project.repo}})
 
 {{project.summary}}
 

--- a/templates/haskell/{{project.name}}/README.md
+++ b/templates/haskell/{{project.name}}/README.md
@@ -1,6 +1,5 @@
 # {{project.name}}
 
-[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io)
 [![Packaging status](https://repology.org/badge/tiny-repos/haskell:{{project.name}}.svg)](https://repology.org/project/haskell:{{project.name}}/versions)
 [![latest packaged versions](https://repology.org/badge/latest-versions/haskell:{{project.name}}.svg)](https://repology.org/project/haskell:{{project.name}}/versions)
 

--- a/templates/nix/README.md
+++ b/templates/nix/README.md
@@ -1,6 +1,6 @@
 # {{project.name}}
 
-[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io)
+[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2F{{project.name}})](https://garnix.io/repo/{{project.repo}})
 
 {{project.summary}}
 


### PR DESCRIPTION
garnix now has repo-level links, so READMEs can link to that instead of the garnix home page.