### PR TITLE
More Haskell template updates

### DIFF
--- a/templates/haskell/.config/project/default.nix
+++ b/templates/haskell/.config/project/default.nix
@@ -76,13 +76,19 @@ in {
         "./cabal.project"
       ];
       vocab.${config.project.name}.accept = [
+        "API"
         "bugfix"
         "comonad"
         "conditionalize"
+        "formatter"
         "functor"
         "GADT"
+        "inline"
         "Kleisli"
         "Kmett"
+        "pragma"
+        "unformatted"
+        "widening"
       ];
     };
   };

--- a/templates/haskell/.config/project/github-ci.nix
+++ b/templates/haskell/.config/project/github-ci.nix
@@ -5,6 +5,7 @@
   ## TODO: Prefer ignoring most known failures once
   ##       https://github.com/orgs/community/discussions/15452 is resolved.
   exclude ? [],
+  include ? [],
   defaultGhcVersion,
   latestGhcVersion,
 }: {
@@ -30,6 +31,7 @@ in {
         strategy = {
           fail-fast = false;
           matrix = {
+            inherit include;
             bounds = ["--prefer-oldest" ""];
             ghc = self.lib.nonNixTestedGhcVersions;
             os = systems;

--- a/templates/haskell/README.md
+++ b/templates/haskell/README.md
@@ -10,18 +10,6 @@
 
 See [the package README](./{{project.name}}/README.md) for usage information.
 
-## development environment
-
-We recommend the following steps to make working in this repository as easy as possible.
-
-### `direnv allow`
-
-This command ensures that any work you do within this repository is done within a consistent reproducible environment. That environment provides various debugging tools, etc. When you leave this directory, you will leave that environment behind, so it doesn’t impact anything else on your system.
-
-### `git config --local include.path ../.config/git/config`
-
-This will apply our repository-specific Git configuration to `git` commands run against this repository. It’s lightweight (you should definitely look at it before applying this command) – it does things like telling `git blame` to ignore formatting-only commits.
-
 ## building
 
 Especially if you are unfamiliar with the {{type.name}} ecosystem, there is a Nix build (both with and without a flake). If you are unfamiliar with Nix, [Nix adjacent](...) can help you get things working in the shortest time and least effort possible.
@@ -38,11 +26,23 @@ This project is built with [Cabal](https://cabal.readthedocs.io/en/stable/index.
 
 ## development
 
+### environment
+
+We recommend the following steps to make working in this repository as easy as possible.
+
+#### `direnv allow`
+
+This command ensures that any work you do within this repository is done within a consistent reproducible environment. That environment provides various debugging tools, etc. When you leave this directory, you will leave that environment behind, so it doesn’t impact anything else on your system.
+
+#### `git config --local include.path ../.config/git/config`
+
+This will apply our repository-specific Git configuration to `git` commands run against this repository. It’s lightweight (you should definitely look at it before applying this command) – it does things like telling `git blame` to ignore formatting-only commits.
+
 ### CI failures
 
 There are a few jobs that may fail during CI and indicate specific changes that need to be made to your PR. If you run into any failures other than those that are listed here, they likely have remedies that are specific to your changes. If you need help replicating or resolving them, or think that they represent general patterns like the ones listed below, inform the maintainers. They can help you resolve them and decide if they should be called out with generic resolution processes.
 
-#### CI / check-bounds (step: check if bounds have changed)
+#### CI / check-bounds (check if bounds have changed)
 
 A failure in the “check if bounds have changed” step indicates that the bounds on direct dependencies have changed.
 
@@ -52,15 +52,15 @@ It currently means that the discovered bounds have been restricted, which is alw
 2. Try to force Cabal to try the previous bounds. If you had manually changed the bounds because you needed some new feature, is it possible to conditionalize use of that feature so that we can also still use and test with older bounds?
 3. Tell CI that you want to keep the bounds the same even though they’re not tested. You do this by adding the old bound to the `extraDependencyVersions` list in flake.nix. This should be done carefully, but one use case is where those bounds _are_ tested by the Nix builds, but not by GitHub.
 
-#### CI / check-licenses (step: check if licenses have changed)
+#### CI / check-licenses (check if licenses have changed)
 
-This means there has _possibly_ been some change in the licensing, but it is not foolproof. This only captures the licensing for one particular Cabal solution, so other solutions may have different transitive dependencies or licenses.
+This means there has _possibly_ been some change in the licensing, but it’s not foolproof. This only captures the licensing for one particular Cabal solution, so other solutions may have different transitive dependencies or licenses.
 
-If there is a new license type in the list, it could affect how consumers of this can use our library. If the new license is not compatible with the existing set, then that is a breaking change. If a package has changed its license, then we can alternatively restrict that package to versions that only use the previous license. Since making a license more restrictive introduces incompatibilities, this should only happen when they bump their major version, but there is no guarantee. In that case, this should just prevent us from extending the bounds, which is fine. But if it requires restricting bounds at the minor or revision level, then that is still a breaking change on our side. Ideally we wouldn’t have to restrict that, but just make sure the consumer is informed about the license change and how to avoid it, but I don’t know how to convey that yet.
+If there is a new license type in the list, it could affect how consumers of this can use our library. If the new license isn’t compatible with the existing set, then that’s a breaking change. If a package has changed its license, then we can alternatively restrict that package to versions that only use the previous license. Since making a license more restrictive introduces incompatibilities, this should only happen when they bump their major version, but there is no guarantee. In that case, this should just prevent us from extending the bounds, which is fine. But if it requires restricting bounds at the minor or revision level, then that’s still a breaking change on our side. Ideally we wouldn’t have to restrict that, but just make sure the consumer is informed about the license change and how to avoid it, but I don’t know how to convey that yet.
 
 If there is a new dependency that has appeared, that should already be reflected in a major version bump. However, not all libraries introduce a major version bump when they add a dependency, and supporting wider version ranges means we may pick up a new dependency without excluding solutions that don’t involve that dependency.
 
-It is tempting to think that moving a dependency from the transitive list to the direct list doesn’t involve a version bump, but that is not necessarily true. First, the transitive dependency must exist on all possible dependency solutions for that to be true. Then, it is also possible for a new revision of a library to _remove_ dependencies, which means they will no longer appear in the transitive graph, invalidating our previous assumption. For this reason, we shouldn’t treat a move from transitive to direct as any different from a new dependency.
+It’s tempting to think that moving a dependency from the transitive list to the direct list doesn’t involve a version bump, but that’s not necessarily true. First, the transitive dependency must exist on all possible dependency solutions for that to be true. Then, it’s also possible for a new revision of a library to _remove_ dependencies, which means they will no longer appear in the transitive graph, invalidating our previous assumption. For this reason, we shouldn’t treat a move from transitive to direct as any different from a new dependency.
 
 #### check formatter
 
@@ -85,7 +85,7 @@ This implies a revision bump in any package that has been reformatted, as well a
 
 Some files committed to the repository don’t match the ones that would be generated by Project Manager. This can happen either because you modified some of the Nix project configuration and forgot to regenerate the files, or because you edited generated files directly rather than editing the Nix project configuration.
 
-If you use Nix, running `project-manager switch` from a project dev shell (or `nix run github:sellout/project-manager -- switch`) anywhere should fix this (although check to see if you lost intentional changes to generated files, and add them via the Nix project configuration instead).
+If you use Nix, running `project-manager switch` from a project `devShell` (or `nix run github:sellout/project-manager -- switch`) anywhere should fix this (although check to see if you lost intentional changes to generated files, and add them via the Nix project configuration instead).
 
 If you don’t use Nix, you will need to mention that in your PR so that one of the maintainers can resolve this for you.
 

--- a/templates/haskell/flake.nix
+++ b/templates/haskell/flake.nix
@@ -106,7 +106,8 @@
           supportedSystems);
 
       lib = {
-        nixifyGhcVersion = version: "ghc" ++ nixpkgs.lib.remove "." version;
+        nixifyGhcVersion = version:
+          "ghc" + nixpkgs.lib.replaceStrings ["."] [""] version;
 
         ## TODO: Extract this automatically from `pkgs.haskellPackages`.
         defaultGhcVersion = "9.6.5";
@@ -161,7 +162,6 @@
             "9.4.8"
             "9.6.4"
             "9.6.5"
-            "9.6.6"
             "9.8.2"
           ];
       };
@@ -201,11 +201,17 @@
           [self.projectConfigurations.${system}.packages.path]
           ## NB: Haskell Language Server no longer supports GHC <9.2, and 9.4
           ##     has an issue with it on i686-linux.
+          ## TODO: Remove the restriction on GHC 9.10 once
+          ##       https://github.com/NixOS/nixpkgs/commit/e87381d634cb1ddd2bd7e121c44fbc926a8c026a
+          ##       finds its way into 24.05.
           ++ nixpkgs.lib.optional
           (
-            if system == "i686-linux"
-            then nixpkgs.lib.versionAtLeast hpkgs.ghc.version "9.4"
-            else nixpkgs.lib.versionAtLeast hpkgs.ghc.version "9.2"
+            (
+              if system == "i686-linux"
+              then nixpkgs.lib.versionAtLeast hpkgs.ghc.version "9.4"
+              else nixpkgs.lib.versionAtLeast hpkgs.ghc.version "9.2"
+            )
+            && nixpkgs.lib.versionOlder hpkgs.ghc.version "9.10"
           )
           hpkgs.haskell-language-server);
 

--- a/templates/haskell/{{project.name}}/README.md
+++ b/templates/haskell/{{project.name}}/README.md
@@ -53,7 +53,7 @@ Type class instances are imported transitively, and thus changing them can impac
 
 This is a consequence of instances being transitively imported. A new major version of a dependency can remove instances, and that can break downstream clients that unwittingly depended on those instances.
 
-A library MAY declare that it always bumps the `A` component when it removes an instance (as this policy dictates). In that case, only `A` widenings need to induce `A` bumps. `B` widenings can be `D` bumps like other widenings, Alternatively, one may compare the APIs when widening a dependency range, and if no instances have been removed, make it a `D` bump.
+A library _may_ declare that it always bumps the `A` component when it removes an instance (as this policy dictates). In that case, only `A` widenings need to induce `A` bumps. `B` widenings can be `D` bumps like other widenings, Alternatively, one may compare the APIs when widening a dependency range, and if no instances have been removed, make it a `D` bump.
 
 ### breaking changes (increments `B`)
 

--- a/templates/haskell/{{project.name}}/docs/license-report.md
+++ b/templates/haskell/{{project.name}}/docs/license-report.md
@@ -2,7 +2,7 @@
 
 # Dependency License Report
 
-Bold-faced **`package-name`**s denote standard libraries bundled with `ghc-9.8.1`.
+Bold-faced **`package-name`**s denote standard libraries bundled with `ghc-9.10.1`.
 
 ## Direct dependencies of `{{project.name}}:lib:{{project.name}}`
 

--- a/templates/haskell/{{project.name}}/{{project.name}}.cabal
+++ b/templates/haskell/{{project.name}}/{{project.name}}.cabal
@@ -39,28 +39,32 @@ source-repository head
   type: git
   location: https://github.com/{{project.repo}}
 
--- This mimics the GHC2021 extension
--- (https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html?highlight=doandifthenelse#extension-GHC2021),
+-- This mimics the GHC2024 extension
+-- (https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html?highlight=doandifthenelse#extension-GHC2024),
 -- but supporting compilers back to GHC 7.10. If the oldest supported compiler
--- is GHC 9.2, then this stanza can be removed and `import: GHC2021` can be
--- replaced by `default-language: GHC2021`.
-common GHC2021
+-- is GHC 9.10, then this stanza can be removed and `import: GHC2024` can be
+-- replaced by `default-language: GHC2024`. If the oldest supported compiler is
+-- GHC 9.2, then this can be simplified by setting `default-language: GHC2021`
+-- and only including the extensions added by GHC2024.
+common GHC2024
   default-language: Haskell2010
   default-extensions:
     BangPatterns
     BinaryLiterals
     ConstraintKinds
+    DataKinds
     DeriveDataTypeable
     DeriveGeneric
     -- DeriveLift -- uncomment if the oldest supported version is GHC 8.10.1+
     DeriveTraversable
     -- DerivingStrategies -- uncomment if the oldest supported version is GHC 8.2.1+
+    DisambiguateRecordFields
     DoAndIfThenElse
     EmptyCase
     ExistentialQuantification
     FlexibleContexts
     FlexibleInstances
-    GADTSyntax
+    GADTs
     GeneralizedNewtypeDeriving
     -- HexFloatLiterals -- uncomment if the oldest supported version is GHC 8.4.1+
     -- ImportQualifiedPost -- uncomment if the oldest supported version is GHC 8.10.1+
@@ -76,6 +80,7 @@ common GHC2021
     PolyKinds
     PostfixOperators
     RankNTypes
+    RoleAnnotations
     ScopedTypeVariables
     StandaloneDeriving
     -- StandaloneKindSignatures -- uncomment if the oldest supported version is GHC 8.10.1+
@@ -83,7 +88,6 @@ common GHC2021
     -- TypeApplications -- uncomment if the oldest supported version is GHC 8.0.1+
     TypeOperators
     UnicodeSyntax
-    NoExplicitNamespaces
 
 flag noisy-deprecations
   description:
@@ -95,13 +99,13 @@ flag noisy-deprecations
     that’s deprecated.
 
 common defaults
-  import: GHC2021
+  import: GHC2024
   build-depends:
     base ^>= {4.8.2, 4.9.1, 4.10.1, 4.11.0, 4.12.0, 4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0, 4.20.0},
   ghc-options:
-    -Weverything
   if impl(ghc >= 8.0.1)
     ghc-options:
+      -Weverything
       -- This one just reports unfixable things, AFAICT.
       -Wno-all-missed-specialisations
       -- Type inference good.
@@ -113,6 +117,9 @@ common defaults
       ghc-options:
         -- This used to warn even when `Safe` was explicit.
         -Wno-safe
+  else
+    ghc-options:
+      -Wall
   if impl(ghc >= 8.10.1)
     ghc-options:
       -- If we didn’t allow inferred-safe imports, nothing would be `Safe`.
@@ -185,15 +192,18 @@ test-suite doctests
   -- TODO: The sections below here are necessary because we don’t have control
   --       over the generated `Build_doctests.hs` file. So we have to silence
   --       all of its warnings one way or another.
-  ghc-options:
-    -Wno-missing-import-lists
-    -Wno-safe
+  if impl(ghc >= 8.0.1)
+    ghc-options:
+      -Wno-missing-import-lists
+      -Wno-safe
+  else
+    ghc-options:
+      -fno-warn-missing-import-lists
   if impl(ghc >= 8.4.1)
     ghc-options:
       -Wno-missing-export-lists
   if impl(ghc >= 8.8.1)
     ghc-options:
-      -- This used to warn even when `Safe` was explicit.
       -Wno-missing-deriving-strategies
   default-extensions:
     -- Since we can’t add `{-# LANGUAGE Safe -#}` to the generated


### PR DESCRIPTION
- add support for `include` to github-ci.nix
- fix some Vale errors
- fix `nixifyGhcVersion`
- remove non-existent GHC 9.6.6 support
- disable HLS on GHC 9.10 (it doesn’t compile with current dependencies)
- add `GHC2024` edition emulation
- add some additional version bounds on GHC flags