### PR TITLE
Fix links in the Elisp template README

### DIFF
--- a/templates/emacs-lisp/README.org
+++ b/templates/emacs-lisp/README.org
@@ -1,8 +1,9 @@
 #+title: {{project.name}}
 
-[[https://garnix.io][https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2Femacs-{{project.name}}]]
-[[https://repology.org/project/emacs-{{project.name}}/versions][https://repology.org/badge/tiny-repos/emacs-{{project.name}}.svg]]
-[[https://repology.org/project/emacs-{{project.name}}/versions][https://repology.org/badge/latest-versions/emacs-{{project.name}}.svg]]
+#+ATTR_HTML: :alt built with garnix
+[[https://garnix.io/repo/{{project.repo}}][https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fsellout%2Femacs-{{project.name}}]]
+[[https://repology.org/project/emacs:{{project.name}}/versions][https://repology.org/badge/tiny-repos/emacs:{{project.name}}.svg]]
+[[https://repology.org/project/emacs:{{project.name}}/versions][https://repology.org/badge/latest-versions/emacs:{{project.name}}.svg]]
 
 {{project.summary}}
 


### PR DESCRIPTION
- add alt text for garnix link
- have garnix link to the repo-specific build page
- correct Repology links to use `:` instead of `-`