### PR TITLE
Avoid infinite recursion in `multiConfig`

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -182,14 +182,12 @@ in {
     homeConfig ? {},
     nixosConfig ? {},
     projectConfig ? {},
-  }: {
-    config =
-      if options ? homebrew
-      then darwinConfig
-      else if options ? home
-      then homeConfig
-      else if options ? boot
-      then nixosConfig
-      else projectConfig;
-  };
+  }:
+    if options ? homebrew
+    then darwinConfig
+    else if options ? home
+    then homeConfig
+    else if options ? boot
+    then nixosConfig
+    else projectConfig;
 }


### PR DESCRIPTION
Previously it generated the containing “config” attribute, but this meant in
some cases in modules Nix wouldn’t be able to figure out the structure it needed
to evaluate the module.

Now it requires you to assign it to “config”.