### PR TITLE
Load the proper modules for project configs

### DIFF
--- a/base/.config/project/emacs-lisp/default.nix
+++ b/base/.config/project/emacs-lisp/default.nix
@@ -19,7 +19,7 @@
   ## In elisp repos, we prefer Org over Markdown, so we don’t need this
   ## formatter.
   programs.treefmt.programs.prettier.enable = lib.mkForce false;
-  vale = {
+  programs.vale = {
     excludes = [
       "*.el"
       "./Eldev"

--- a/base/.config/project/nix/default.nix
+++ b/base/.config/project/nix/default.nix
@@ -1,4 +1,8 @@
 {
+  imports = [
+    ./..
+  ];
+
   ## This defaults to `true`, because I want most projects to be
   ## contributable-to by non-Nix users. However, Nix-specific projects can lean
   ## into Project Manager and avoid committing extra files.

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -154,11 +154,11 @@ in {
         // args
         // {
           modules =
-            modules
-            ++ [
+            [
               {_module.args.flaky = self;}
-              self.projectModules.default
-            ];
+              primaryModule
+            ]
+            ++ modules;
         }
       );
   in {


### PR DESCRIPTION
This is a bug that would have been caught by #94. Regardless of which language
you intended to load a project config for, it always loaded the default. And
that hid additional bugs in the language-specific configs.