### PR TITLE
Fix a bug in the untested Haskell module

### DIFF
--- a/base/.config/project/haskell/default.nix
+++ b/base/.config/project/haskell/default.nix
@@ -5,6 +5,7 @@
   pkgs,
   self,
   supportedSystems,
+  ...
 }: {
   imports = [
     ./..


### PR DESCRIPTION
We don’t test Haskell because the template has some unique issues, which means I
didn’t notice this bug until trying to use it downstream.