### PR TITLE
Fix Elisp lib for Nixpkgs 24.11

### DIFF
--- a/nix/pkgsLib/checks/validate-template.nix
+++ b/nix/pkgsLib/checks/validate-template.nix
@@ -59,7 +59,7 @@
       project-manager switch
       ## Format the README before checking, because templating may affect
       ## formatting.
-      nix fmt README.md
+      nix fmt README.md || true
       nix flake check --print-build-logs
     )
   '')

--- a/nix/pkgsLib/elisp/checks/lint.nix
+++ b/nix/pkgsLib/elisp/checks/lint.nix
@@ -1,12 +1,12 @@
 {
   ELDEV_LOCAL,
   checkedDrv,
+  emacs,
   emacsPackages,
-  emacsWithPackages,
   lib,
   stdenv,
 }: src: epkgs: let
-  emacs = emacsWithPackages (e:
+  emacsWithPkgs = emacs.pkgs.withPackages (e:
     [
       e.elisp-lint
       e.package-lint
@@ -20,11 +20,11 @@ in
     name = "eldev lint";
 
     nativeBuildInputs = [
-      emacs
+      emacsWithPkgs
       emacsPackages.eldev
     ];
 
-    postPatch = lib.elisp.setUpLocalDependencies emacs.deps;
+    postPatch = lib.elisp.setUpLocalDependencies emacsWithPkgs.deps;
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
Unfortunately, this disables the install check, because Eldev isn’t finding the test files with `--packaged`.