### PR TITLE
Add a version constraint to cabal-plan

### DIFF
--- a/base/.config/project/haskell/github-ci.nix
+++ b/base/.config/project/haskell/github-ci.nix
@@ -272,7 +272,10 @@ in {
             }
             {
               run = ''
+                ## The `--constraint` is needed to work around
+                ## haskell-hvr/cabal-plan#114
                 cabal install cabal-plan \
+                  --constraint 'cabal-plan < 0.7.6' \
                   --flags='exe license-report' \
                   --ghc-options='-Wwarn'
               '';


### PR DESCRIPTION
This is a workaround for haskell-hvr/cabal-plan#114.