### PR TITLE
Move GitHub systems from Haskell template

### DIFF
--- a/base/.config/project/haskell/default.nix
+++ b/base/.config/project/haskell/default.nix
@@ -91,6 +91,20 @@
       "--enable-benchmarks"
       "--enable-tests"
     ];
+    ## https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+    ## for the current list of available runners.
+    systems = [
+      "macos-15" #         aarch64-darwin
+      ## NB: This is the final x86_64-darwin image that GitHub will provide, and
+      ##     it will be available through August 2027. See
+      ##     actions/runner-images#13045 for details.
+      "macos-15-intel" #   x86_64-darwin
+      "ubuntu-24.04" #     x86_64-linux
+      "ubuntu-24.04-arm" # aarch64-linux
+      ## TODO: GHCup doesn’t install on this platform at all.
+      # "windows-11-arm" #   aarch64-windows
+      "windows-2025" #     x86_64-windows
+    ];
   };
   ## TODO: Remove this once projects have switched to Cabal.nix generation.
   services.nix-ci.allow-import-from-derivation = lib.mkForce true;

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,9 @@
   description = "Shared configuration for dev environments";
 
   nixConfig = {
+    ## NB: This is a consequence of using `self.pkgsLib.runEmptyCommand`, which
+    ##     allows us to sandbox derivations that otherwise can’t be.
+    allow-import-from-derivation = true;
     ## https://github.com/NixOS/rfcs/blob/master/rfcs/0045-deprecate-url-syntax.md
     extra-experimental-features = ["no-url-literals"];
     extra-substituters = ["https://cache.garnix.io"];

--- a/nix/pkgsLib/checks/default.nix
+++ b/nix/pkgsLib/checks/default.nix
@@ -3,6 +3,9 @@
   runEmptyCommand,
   self,
 }: let
+  ## This produces a fixed-output derivation so we can sandbox a derivation that
+  ## otherwise couldn’t be. However, it uses IFD, so only use it on derivations
+  ## that wouldn’t otherwise be sandboxable.
   simple = name: src: nativeBuildInputs:
     runEmptyCommand name {inherit nativeBuildInputs src;};
 in {

--- a/nix/pkgsLib/default.nix
+++ b/nix/pkgsLib/default.nix
@@ -9,6 +9,9 @@
   ## A command where we don’t preserve any output can be more lax than most
   ## derivations. By turning it into a fixed-output derivation based on the
   ## command, we can weaken some of the sandbox constraints.
+  ##
+  ## The tradeoff is that this uses IFD, so it should only be used for
+  ## derivations that would otherwise not be sandboxable.
   runEmptyCommand = name: attrs: command: let
     outputHashAlgo = "sha256";
     ## Runs a command and returns its output as a string.


### PR DESCRIPTION
This also
- switches from `macos-13` to `macos-15-intel` for x86_64-darwin builds, as required by actions/runner-images#13046; and
- enables `allow-import-from-derivation` to make the flake more portable.