### PR TITLE
Cancel old Haskell build matrices

### DIFF
--- a/base/.config/project/haskell/github-ci.nix
+++ b/base/.config/project/haskell/github-ci.nix
@@ -169,6 +169,10 @@ in {
           "synchronize"
         ];
       };
+      concurrency = {
+        group = "\${{ github.workflow }}-\${{ github.ref || github.run_id }}";
+        cancel-in-progress = true;
+      };
       jobs = let
         ## NB: This uses haskell-actions/setup instead of haskell/ghcup-setup
         ##     primarily because of haskell/ghcup-setup#18.


### PR DESCRIPTION
Haskell projects create a large build matrix, and when new changes are pushed, we want to cancel the previous to minimize wasting CI resources (in March, GitHub actually cut me off, so I’m using _way_ too much CI time).