### PR TITLE
Read .envrc files in ancestor directories

### DIFF
--- a/base/.config/project/direnv.nix
+++ b/base/.config/project/direnv.nix
@@ -2,6 +2,9 @@
   programs.direnv = {
     auto-allow = true;
     envrc = ''
+      ## This gives us cascading behavior. See
+      ## https://github.com/direnv/direnv/blob/master/man/direnv-stdlib.1.md#source_up_if_exists-filename
+      source_up_if_exists
       use flake
     '';
   };


### PR DESCRIPTION
This is helpful with Astrolabe, which uses Direnv to set up references between repositories in a task.