### PR TITLE
Don’t publish private repos

### DIFF
--- a/base/.config/project/default.nix
+++ b/base/.config/project/default.nix
@@ -86,8 +86,8 @@
 
   ## publishing
   services = {
-    flakehub.enable = true;
-    flakestry.enable = true;
+    flakehub.enable = !config.services.github.settings.repository.private;
+    flakestry.enable = !config.services.github.settings.repository.private;
     github.enable = true;
   };
 }


### PR DESCRIPTION
Disable publishing private repos to Flakestry or FlakeHub.