### PR TITLE
Require all repos to explicitly set visibility

### DIFF
--- a/.config/project/default.nix
+++ b/.config/project/default.nix
@@ -28,10 +28,13 @@
   };
 
   services = {
-    github.settings.repository.topics = [
-      "development"
-      "nix-flakes"
-    ];
+    github.settings.repository = {
+      private = false;
+      topics = [
+        "development"
+        "nix-flakes"
+      ];
+    };
     ## Only run Renovate monthly (on the 15th). This reduces the amount of
     ## cascading Nixpkgs updates, which makes it more likely that checked out
     ## repos are on the same revision.

--- a/base/.config/project/github.nix
+++ b/base/.config/project/github.nix
@@ -5,6 +5,13 @@
   supportedSystems,
   ...
 }: {
+  assertions = [
+    {
+      assertion = config.services.github.settings.repository ? private;
+      message = "the project configuration needs to set `services.github.settings.repository.private`";
+    }
+  ];
+
   services.github = {
     settings = {
       ## These settings are synced to GitHub by
@@ -16,7 +23,6 @@
         name = config.project.name;
         description = config.project.summary;
         # homepage = "https://example.github.io/";
-        private = false;
         has_issues = true;
         has_projects = true;
         has_wiki = true;


### PR DESCRIPTION
Previously everything defaulted to public, which caused a number of issues including having repos be accidentally public; having repos that were private, but that the configuration thought were public; etc.